### PR TITLE
Recommend yarn install instead of yarn bootstrap

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -7,10 +7,10 @@ To propose improvements, feel free to submit a PR or open an Issue.
 
 ## Setup your developer Environment
 
-To get started with the project, run `yarn bootstrap` in the root directory to install the required dependencies for each package:
+To get started with the project, run `yarn install` in the root directory to install the required dependencies for each package:
 
 ```sh
-yarn bootstrap
+yarn install
 ```
 
 ### Native Module development


### PR DESCRIPTION
### What does this PR do?

`yarn bootstrap` gives `Command not found` error as of `yarn@1.22.10`, while `yarn install` works fine. It is also possible to use `npm install`, but this approach changes quite a lot in `package-lock.json`, because it happily does the following change as well by some reason:

```diff
--- a/package.json
+++ b/package.json
@@ -40,8 +40,8 @@
   },
   "dependencies": {
     "@react-navigation/native": "^5.9.2",
-    "react": "16.13.1",
-    "react-native": "0.63.4",
+    "react": "*",
+    "react-native": "*",
     "react-native-gesture-handler": "^1.10.1"
   },
   "devDependencies": {
```