### PR TITLE
RUMM-1165: Stop ReactNative views when app goes into background

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,6 +53,7 @@ import { DdRumReactNavigationTracking } from 'dd-sdk-reactnative';
     // …
     </NavigationContainer>
 ```
+Please note, that only one `NavigationContainer` can be tracked at the time. If you need to track another container, you need to stop tracking previous one first.
 
 ### Adding custom attributes
 

--- a/README.md
+++ b/README.md
@@ -53,7 +53,7 @@ import { DdRumReactNavigationTracking } from 'dd-sdk-reactnative';
     // …
     </NavigationContainer>
 ```
-Please note, that only one `NavigationContainer` can be tracked at the time. If you need to track another container, you need to stop tracking previous one first.
+**Note**: Only one `NavigationContainer` can be tracked at the time. If you need to track another container, stop tracking previous one first.
 
 ### Adding custom attributes
 

--- a/example/src/NavigationRoot.tsx
+++ b/example/src/NavigationRoot.tsx
@@ -1,4 +1,4 @@
 import type { NavigationContainerRef } from '@react-navigation/native';
 import * as React from 'react';
 
-export const navigationRef:React.RefObject<NavigationContainerRef> = React.createRef();
+export const navigationRef: React.RefObject<NavigationContainerRef> = React.createRef();

--- a/src/__tests__/rum/instrumentation/DdRumReactNavigationTracking.test.tsx
+++ b/src/__tests__/rum/instrumentation/DdRumReactNavigationTracking.test.tsx
@@ -5,7 +5,7 @@
  */
 
 import React from 'react';
-import { View, Text, Button } from 'react-native';
+import { View, Text, Button, AppState } from 'react-native';
 import { NavigationContainer, NavigationContainerRef } from '@react-navigation/native';
 import { DdRum } from '../../../index';
 import DdRumReactNavigationTracking from '../../../rum/instrumentation/DdRumReactNavigationTracking';
@@ -16,10 +16,22 @@ jest.mock('../../../index', () => {
     return {
         DdRum: {
             // eslint-disable-next-line @typescript-eslint/no-empty-function
-            startView: jest.fn().mockImplementation(() => { })
+            startView: jest.fn().mockImplementation(() => { }),
+            stopView: jest.fn().mockImplementation(() => { })
         },
     };
 });
+
+let capturedAppStateChangeCallback = null;
+
+jest.mock('react-native/Libraries/AppState/AppState', () => ({
+    addEventListener: jest.fn((event, callback) => {
+        if (event === 'change') {
+            capturedAppStateChangeCallback = callback;
+        }
+    }),
+    removeEventListener: jest.fn().mockImplementation(() => { })
+}));
 
 const { Screen, Navigator } = createStackNavigator();
 const navigationRef1: React.RefObject<NavigationContainerRef> = React.createRef();
@@ -31,8 +43,16 @@ jest.useFakeTimers();
 
 
 beforeEach(() => {
+    
     jest.setTimeout(20000);
     DdRum.startView.mockClear();
+    DdRum.stopView.mockClear();
+    AppState.addEventListener.mockClear();
+    AppState.removeEventListener.mockClear();
+
+    DdRumReactNavigationTracking.registeredContainer = null;
+    DdRumReactNavigationTracking.navigationStateChangeListener = null;
+    DdRumReactNavigationTracking.appStateListener = null;
 })
 
 // Unit tests
@@ -70,7 +90,7 @@ it('M send a related RUM ViewEvent W switching screens { navigationContainer lis
     expect(DdRum.startView.mock.calls[1][3]).toStrictEqual({});
 })
 
-it('M only register once W startTrackingViews{ mutliple times }', async () => {
+it('M only register once W startTrackingViews{ multiple times }', async () => {
 
     // GIVEN
     const { getByText } = render(<FakeNavigator1 />);
@@ -114,7 +134,7 @@ it('M do nothing W startTrackingViews { undefined NavigationContainerRef ', asyn
     expect(DdRum.startView.mock.calls.length).toBe(0);
 })
 
-it('M send a RUM ViewEvent for each W startTrackingViews { mutliple navigation containers }', async () => {
+it('M send a RUM ViewEvent for each W startTrackingViews { multiple navigation containers w first not detached }', async () => {
 
     // GIVEN
     const testUtils1: { getByText } = render(<FakeNavigator1 />);
@@ -122,6 +142,7 @@ it('M send a RUM ViewEvent for each W startTrackingViews { mutliple navigation c
     const testUtils2: { getByText } = render(<FakeNavigator2 />);
     const goToAboutButton2 = testUtils2.getByText('Go to About');
     DdRumReactNavigationTracking.startTrackingViews(navigationRef1.current);
+    // this call will be ignored, because only one NavigationContainer tracking is supported at the time
     DdRumReactNavigationTracking.startTrackingViews(navigationRef2.current);
 
     // WHEN
@@ -131,33 +152,126 @@ it('M send a RUM ViewEvent for each W startTrackingViews { mutliple navigation c
     fireEvent(goToAboutButton2, "press");
 
     // THEN
+    expect(DdRum.startView.mock.calls.length).toBe(2);
+    expect(DdRum.startView.mock.calls[1][0]).toBe(navigationRef1.current?.getCurrentRoute()?.key);
+    expect(DdRum.startView.mock.calls[1][1]).toBe(navigationRef1.current?.getCurrentRoute()?.name);
+    expect(DdRum.startView.mock.calls[1][3]).toStrictEqual({});
+})
+
+it('M send a RUM ViewEvent for each W startTrackingViews { multiple navigation containers w first is detached }', async () => {
+
+    // GIVEN
+    const testUtils1: { getByText } = render(<FakeNavigator1 />);
+    const goToAboutButton1 = testUtils1.getByText('Go to About');
+    const testUtils2: { getByText } = render(<FakeNavigator2 />);
+    const goToAboutButton2 = testUtils2.getByText('Go to About');
+
+    // WHEN
+    expect(goToAboutButton1).toBeTruthy();
+    expect(goToAboutButton2).toBeTruthy();
+
+    DdRumReactNavigationTracking.startTrackingViews(navigationRef1.current);
+    fireEvent(goToAboutButton1, "press");
+    DdRumReactNavigationTracking.stopTrackingViews(navigationRef1.current);
+
+    DdRumReactNavigationTracking.startTrackingViews(navigationRef2.current);
+
+    const navigationRef2StartRoute = navigationRef2.current.getCurrentRoute();
+
+    fireEvent(goToAboutButton2, "press");
+
+    // THEN
     expect(DdRum.startView.mock.calls.length).toBe(4);
-    expect(DdRum.startView.mock.calls[2][0]).toBe(navigationRef1.current?.getCurrentRoute()?.key);
-    expect(DdRum.startView.mock.calls[2][1]).toBe(navigationRef1.current?.getCurrentRoute()?.name);
+    expect(DdRum.startView.mock.calls[2][0]).toBe(navigationRef2StartRoute.key);
+    expect(DdRum.startView.mock.calls[2][1]).toBe(navigationRef2StartRoute.name);
     expect(DdRum.startView.mock.calls[2][3]).toStrictEqual({});
     expect(DdRum.startView.mock.calls[3][0]).toBe(navigationRef2.current?.getCurrentRoute()?.key);
     expect(DdRum.startView.mock.calls[3][1]).toBe(navigationRef2.current?.getCurrentRoute()?.name);
     expect(DdRum.startView.mock.calls[3][3]).toStrictEqual({});
 })
 
-it('M send a RUM ViewEvent for each W switching screens { mutliple navigation containers }', async () => {
+it('M send a RUM ViewEvent for each W switching screens { multiple navigation containers }', async () => {
 
     // GIVEN
     render(<FakeNavigator1 />);
     render(<FakeNavigator2 />);
+
+    // WHEN
     DdRumReactNavigationTracking.startTrackingViews(navigationRef1.current);
     DdRumReactNavigationTracking.startTrackingViews(navigationRef2.current);
 
+    // THEN
+    expect(DdRum.startView.mock.calls.length).toBe(1);
+    expect(DdRum.startView.mock.calls[0][0]).toBe(navigationRef1.current?.getCurrentRoute()?.key);
+    expect(DdRum.startView.mock.calls[0][1]).toBe(navigationRef1.current?.getCurrentRoute()?.name);
+    expect(DdRum.startView.mock.calls[0][3]).toStrictEqual({});
+})
+
+it('M register AppState listener only once', async () => {
+
+    // GIVEN
+    render(<FakeNavigator1 />);
+    render(<FakeNavigator2 />);
+
     // WHEN
+    DdRumReactNavigationTracking.startTrackingViews(navigationRef1.current);
+    DdRumReactNavigationTracking.stopTrackingViews(navigationRef1.current);
+    DdRumReactNavigationTracking.startTrackingViews(navigationRef2.current);
 
     // THEN
+    expect(AppState.addEventListener.mock.calls.length).toBe(1);
+    expect(AppState.removeEventListener.mock.calls.length).toBe(0);
+})
+
+it('M stop active view W app goes into background', async () => {
+
+    // GIVEN
+    render(<FakeNavigator1 />);
+
+    DdRumReactNavigationTracking.startTrackingViews(navigationRef1.current);
+
+    // WHEN
+    capturedAppStateChangeCallback('background');
+
+    // THEN
+    expect(DdRum.stopView.mock.calls.length).toBe(1);
+    expect(DdRum.stopView.mock.calls[0][0]).toBe(navigationRef1.current?.getCurrentRoute()?.key);
+    expect(DdRum.stopView.mock.calls[0][2]).toStrictEqual({});
+
+})
+
+it('M start last view W app goes into foreground', async () => {
+
+    // GIVEN
+    render(<FakeNavigator1 />);
+
+    DdRumReactNavigationTracking.startTrackingViews(navigationRef1.current);
+
+    // WHEN
+    capturedAppStateChangeCallback('background');
+    capturedAppStateChangeCallback('active');
+
+    // THEN
+    expect(DdRum.stopView.mock.calls.length).toBe(1);
     expect(DdRum.startView.mock.calls.length).toBe(2);
     expect(DdRum.startView.mock.calls[0][0]).toBe(navigationRef1.current?.getCurrentRoute()?.key);
     expect(DdRum.startView.mock.calls[0][1]).toBe(navigationRef1.current?.getCurrentRoute()?.name);
     expect(DdRum.startView.mock.calls[0][3]).toStrictEqual({});
-    expect(DdRum.startView.mock.calls[1][0]).toBe(navigationRef2.current?.getCurrentRoute()?.key);
-    expect(DdRum.startView.mock.calls[1][1]).toBe(navigationRef2.current?.getCurrentRoute()?.name);
-    expect(DdRum.startView.mock.calls[1][3]).toStrictEqual({});
+})
+
+it('M not stop view W no navigator attached', async () => {
+
+    // GIVEN
+    render(<FakeNavigator1 />);
+
+    DdRumReactNavigationTracking.startTrackingViews(navigationRef1.current);
+    DdRumReactNavigationTracking.stopTrackingViews(navigationRef1.current);
+
+    // WHEN
+    capturedAppStateChangeCallback('background');
+
+    // THEN
+    expect(DdRum.stopView.mock.calls.length).toBe(0);
 })
 
 


### PR DESCRIPTION
### What does this PR do?

This is current a draft for RUMM-1165 issue, stating that views should be stopped when app goes into background. Solution proposed is currently dirty, because the following factors:

1. We can know if app is going into background using [AppState](https://reactnative.dev/docs/appstate) class, which itself is singleton, so it is not linked to any navigation container and events it emits are neither linked.
2. Once we get `background` or `active` events we need to either stop or resume the current view. And to know the current view we need to access `NavigationContainer` object either using a reference (not possible, because it is in the `WeakSet`, and weak collections in JS are not enumerable by design, so it is not possible to get an object from the collection, see more [here](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/WeakSet). And anyway if it would be possible, then we would have a problem of knowing which `NavigationContainer` to query) or using [props.navigation](https://reactnavigation.org/docs/navigation-prop/), but for that we need to be inside the component, which is obviously not possible at the SDK level.

So considering that proposed solution is simply record last seen view in the static variable and use it to stop view when app goes into background, or start view when app becomes active again (`background` -> `foreground` transition is not covered by `NavigationContainer` `state` change listener, unfortunately).

We could try to use non-weak collection to store `NavigationContainer` reference, but that would lead to a risk of memory leak. There is a possibility also to make SDK interface non-static and give customer an opportunity to control its lifecycle, but this would require breaking changes in the SDK API itself.

Change has no tests yet, because it is draft to discuss.

### Review checklist (to be filled by reviewers)

- [x] Feature or bugfix MUST have appropriate tests
- [x] Make sure you discussed the feature or bugfix with the maintaining team in an Issue
- [x] Make sure each commit and the PR mention the Issue number (cf the [CONTRIBUTING](CONTRIBUTING.md) doc)

