### PR TITLE
RUMM-1173 Fix resource discrepancies

### DIFF
--- a/src/__tests__/rum/instrumentation/DdRumResourceTracking.test.tsx
+++ b/src/__tests__/rum/instrumentation/DdRumResourceTracking.test.tsx
@@ -116,7 +116,7 @@ it('M intercept XHR request W startTracking() + XHR.open() + XHR.send()', async 
     expect(DdRum.stopResource.mock.calls.length).toBe(1);
     expect(DdRum.stopResource.mock.calls[0][0]).toBe(DdRum.startResource.mock.calls[0][0]);
     expect(DdRum.stopResource.mock.calls[0][1]).toBe(200);
-    expect(DdRum.stopResource.mock.calls[0][2]).toBe('XHR');
+    expect(DdRum.stopResource.mock.calls[0][2]).toBe('xhr');
 
     expect(xhr.originalOpenCalled).toBe(true);
     expect(xhr.originalSendCalled).toBe(true);
@@ -144,7 +144,7 @@ it('M intercept failing XHR request W startTracking() + XHR.open() + XHR.send()'
     expect(DdRum.stopResource.mock.calls.length).toBe(1);
     expect(DdRum.stopResource.mock.calls[0][0]).toBe(DdRum.startResource.mock.calls[0][0]);
     expect(DdRum.stopResource.mock.calls[0][1]).toBe(500);
-    expect(DdRum.stopResource.mock.calls[0][2]).toBe('XHR');
+    expect(DdRum.stopResource.mock.calls[0][2]).toBe('xhr');
 
     expect(xhr.originalOpenCalled).toBe(true);
     expect(xhr.originalSendCalled).toBe(true);
@@ -173,7 +173,7 @@ it('M intercept aborted XHR request W startTracking() + XHR.open() + XHR.send() 
     expect(DdRum.stopResource.mock.calls.length).toBe(1);
     expect(DdRum.stopResource.mock.calls[0][0]).toBe(DdRum.startResource.mock.calls[0][0]);
     expect(DdRum.stopResource.mock.calls[0][1]).toBe(0);
-    expect(DdRum.stopResource.mock.calls[0][2]).toBe('XHR');
+    expect(DdRum.stopResource.mock.calls[0][2]).toBe('xhr');
 
     expect(xhr.originalOpenCalled).toBe(true);
     expect(xhr.originalSendCalled).toBe(true);

--- a/src/rum/instrumentation/DdRumResourceTracking.tsx
+++ b/src/rum/instrumentation/DdRumResourceTracking.tsx
@@ -135,7 +135,7 @@ export class DdRumResourceTracking {
         "_dd.trace_id": xhrProxy._datadog_xhr.traceId
       }
     ).then(() => {
-      DdRum.stopResource(key, xhrProxy.status, "XHR", Date.now(), {});
+      DdRum.stopResource(key, xhrProxy.status, "xhr", Date.now(), {});
     })
   }
 


### PR DESCRIPTION
### What does this PR do?

The iOS bridge is case sensitive when it comes to converting strings to enums, hence the bug seen when tracking XHR resources.