### PR TITLE
RUMM-1202 Handle nested navigation routes

### DIFF
--- a/src/rum/instrumentation/DdRumReactNavigationTracking.tsx
+++ b/src/rum/instrumentation/DdRumReactNavigationTracking.tsx
@@ -56,7 +56,12 @@ export default class DdRumReactNavigationTracking {
         if (this.navigationStateChangeListener == null) {
             // eslint-disable-next-line @typescript-eslint/no-explicit-any
             this.navigationStateChangeListener = (event: EventArg<string, boolean, any>) => {
-                this.handleRouteNavigation(event.data?.state?.routes[event.data?.state?.index]);
+                let nestedRoute = event.data?.state?.routes[event.data?.state?.index];
+                while (nestedRoute.state != undefined) {
+                    nestedRoute = nestedRoute.state.routes[nestedRoute.state.index];
+                }
+
+                this.handleRouteNavigation(nestedRoute);
             };
         }
         return this.navigationStateChangeListener;


### PR DESCRIPTION
### What does this PR do?

Update the React Navigation tracking to handle cases where the navigation uses nested navigator (the event has nested routes, and the one we want are the deepest ones).