### PR TITLE
RUMM-1216: Use react-native as a source

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -15,4 +15,5 @@ Anything else we should know when reviewing?
 - [ ] Feature or bugfix MUST have appropriate tests
 - [ ] Make sure you discussed the feature or bugfix with the maintaining team in an Issue
 - [ ] Make sure each commit and the PR mention the Issue number (cf the [CONTRIBUTING](CONTRIBUTING.md) doc)
+- [ ] If this PR is auto-generated, please make sure also to manually update the code related to the change
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -111,7 +111,14 @@ Example code:
 import { DdSdkReactNative, DdSdkReactNativeConfiguration } from 'dd-sdk-reactnative';
 
 const App: () => React$Node = () => {
-  let config = new DdSdkReactNativeConfiguration("token", "env", "appId");
+  const config = new DdSdkReactNativeConfiguration(
+    "<CLIENT_TOKEN>",
+    "<ENVIRONMENT_NAME>",
+    "<RUM_APPLICATION_ID>",
+    true, // track User interactions (e.g.: Tap on buttons)
+    true, // track XHR Resources
+    true // track Errors
+  )
   DdSdkReactNative.initialize(config);
   ...
 ```

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -108,11 +108,11 @@ use_frameworks!
 Now you can go back to your `App.js/tsx` and use `dd-sdk-reactnative` from there
 Example code:
 ```
-import { DdSdk, DdSdkConfiguration } from 'dd-sdk-reactnative';
+import { DdSdkReactNative, DdSdkReactNativeConfiguration } from 'dd-sdk-reactnative';
 
 const App: () => React$Node = () => {
-  let config = new DdSdkConfiguration("token", "env", "appId");
-  DdSdk.initialize(config);
+  let config = new DdSdkReactNativeConfiguration("token", "env", "appId");
+  DdSdkReactNative.initialize(config);
   ...
 ```
 

--- a/README.md
+++ b/README.md
@@ -92,7 +92,14 @@ If our automatic instrumentation doesn't suit your needs, you can manually creat
 import { DdSdkReactNative, DdSdkReactNativeConfiguration, DdLogs, DdRum } from 'dd-sdk-reactnative';
 
 // Initialize the SDK
-const config = new DdSdkReactNativeConfiguration("<CLIENT_TOKEN>", "<ENVIRONMENT_NAME>", "<RUM_APPLICATION_ID>");
+const config = new DdSdkReactNativeConfiguration(
+    "<CLIENT_TOKEN>",
+    "<ENVIRONMENT_NAME>",
+    "<RUM_APPLICATION_ID>",
+    true, // track User interactions (e.g.: Tap on buttons)
+    true, // track XHR Resources
+    true // track Errors
+)
 DdSdkReactNative.initialize(config);
 
 // Send logs (use the debug, info, warn of error methods)

--- a/README.md
+++ b/README.md
@@ -61,10 +61,10 @@ You can attach user information to all RUM events to get more detailed informati
 
 #### User information
 
-For user specifc information, you can use the following code wherever you want in your code (after the SDK has been initialized). The `id`, `name` and `email` attributes are built into the Datadog UI, but you can add any attribute that makes sense to your app.
+For user specific information, you can use the following code wherever you want in your code (after the SDK has been initialized). The `id`, `name` and `email` attributes are built into the Datadog UI, but you can add any attribute that makes sense to your app.
 
 ```js
-DdSdk.setUser({
+DdSdkReactNative.setUser({
     id: "1337", 
     name: "John Smith", 
     email: "john@example.com", 
@@ -77,7 +77,7 @@ DdSdk.setUser({
 You can also keep global attributes to track information about a specific session, such as A/B testing configuration, advert campaign origin, or cart status.
 
 ```js
-DdSdk.setAttributes({
+DdSdkReactNative.setAttributes({
     profile_mode: "wall",
     chat_enabled: true,
     campaign_origin: "example_ad_network"
@@ -89,11 +89,11 @@ DdSdk.setAttributes({
 If our automatic instrumentation doesn't suit your needs, you can manually create RUM Events and Logs as follow:
 
 ```js
-import { DdSdk, DdSdkConfiguration, DdLogs, DdRum } from 'dd-sdk-reactnative';
+import { DdSdkReactNative, DdSdkReactNativeConfiguration, DdLogs, DdRum } from 'dd-sdk-reactnative';
 
 // Initialize the SDK
-const config = new DdSdkConfiguration("<CLIENT_TOKEN>", "<ENVIRONMENT_NAME>", "<RUM_APPLICATION_ID>");
-DdSdk.initialize(config);
+const config = new DdSdkReactNativeConfiguration("<CLIENT_TOKEN>", "<ENVIRONMENT_NAME>", "<RUM_APPLICATION_ID>");
+DdSdkReactNative.initialize(config);
 
 // Send logs (use the debug, info, warn of error methods)
 DdLogs.debug("Lorem ipsum dolor sit amet…", 0, {});

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -130,7 +130,6 @@ dependencies {
   // noinspection GradleDynamicVersion
   api 'com.facebook.react:react-native:+'
   
-  implementation "com.datadoghq:dd-sdk-android:1.8.0-alpha1"
   implementation "com.datadoghq:dd-bridge-android:0.2.0"
 
   implementation "org.jetbrains.kotlin:kotlin-stdlib:$kotlin_version"

--- a/example/index.tsx
+++ b/example/index.tsx
@@ -1,12 +1,10 @@
 import { AppRegistry } from 'react-native';
 import App from './src/App';
 import { name as appName } from './app.json';
-import { NativeModules } from 'react-native'
 import {
     DdSdkReactNative,
     DdSdkReactNativeConfiguration,
     DdLogs,
-    DdSdk
 } from 'dd-sdk-reactnative';
 
 import { CLIENT_TOKEN, ENVIRONMENT, APPLICATION_ID } from './src/ddCredentials';
@@ -29,9 +27,9 @@ DdSdkReactNative.initialize(config).then(() => {
         bar: 'xyz',
     })
 
-    DdSdk.setUser({id: "1337", name: "Xavier", email: "xg@example.com", type: "premium"})
+    DdSdkReactNative.setUser({id: "1337", name: "Xavier", email: "xg@example.com", type: "premium"})
 
-    DdSdk.setAttributes({campaign: "react-native-bs"})
+    DdSdkReactNative.setAttributes({campaign: "react-native-bs"})
 });
 
 AppRegistry.registerComponent(appName, () => App);

--- a/src/DdSdkReactNative.tsx
+++ b/src/DdSdkReactNative.tsx
@@ -58,10 +58,7 @@ export class DdSdkReactNative {
      */
     // eslint-disable-next-line @typescript-eslint/ban-types
     static setAttributes(attributes: object): Promise<void> {
-        return new Promise<void>((resolve => {
-            DdSdk.setAttributes(attributes)
-            resolve()
-        }));
+        return DdSdk.setAttributes(attributes)
     }
 
     /**
@@ -71,10 +68,7 @@ export class DdSdkReactNative {
      */
     // eslint-disable-next-line @typescript-eslint/ban-types
     static setUser(user: object): Promise<void> {
-        return new Promise<void>((resolve => {
-            DdSdk.setUser(user)
-            resolve()
-        }))
+        return DdSdk.setUser(user)
     }
 
     private static enableFeatures(configuration: DdSdkReactNativeConfiguration) {

--- a/src/DdSdkReactNative.tsx
+++ b/src/DdSdkReactNative.tsx
@@ -5,13 +5,11 @@
  */
 
 import type { DdSdkReactNativeConfiguration } from "./DdSdkReactNativeConfiguration"
-import { DdSdkConfiguration, DdSdkType } from "./types"
-import { NativeModules } from 'react-native'
+import { DdSdkConfiguration } from "./types"
+import { DdSdk } from "./dd-foundation"
 import { DdRumUserInteractionTracking } from './rum/instrumentation/DdRumUserInteractionTracking'
 import { DdRumErrorTracking } from './rum/instrumentation/DdRumErrorTracking'
 import { DdRumResourceTracking } from './rum/instrumentation/DdRumResourceTracking'
-
-const DdSdk: DdSdkType = NativeModules.DdSdk;
 
 /**
  * This class initializes the Datadog SDK, and sets up communication with the server.
@@ -51,6 +49,32 @@ export class DdSdkReactNative {
             resolve()
         }))
 
+    }
+
+    /**
+     * Sets the global context (set of attributes) attached with all future Logs, Spans and RUM events.
+     * @param attributes: The global context attributes.
+     * @returns a Promise.
+     */
+    // eslint-disable-next-line @typescript-eslint/ban-types
+    static setAttributes(attributes: object): Promise<void> {
+        return new Promise<void>((resolve => {
+            DdSdk.setAttributes(attributes)
+            resolve()
+        }));
+    }
+
+    /**
+     * Set the user information.
+     * @param user: The user object (use builtin attributes: 'id', 'email', 'name', and/or any custom attribute).
+     * @returns a Promise.
+     */
+    // eslint-disable-next-line @typescript-eslint/ban-types
+    static setUser(user: object): Promise<void> {
+        return new Promise<void>((resolve => {
+            DdSdk.setUser(user)
+            resolve()
+        }))
     }
 
     private static enableFeatures(configuration: DdSdkReactNativeConfiguration) {

--- a/src/DdSdkReactNative.tsx
+++ b/src/DdSdkReactNative.tsx
@@ -17,6 +17,9 @@ const DdSdk: DdSdkType = NativeModules.DdSdk;
  * This class initializes the Datadog SDK, and sets up communication with the server.
  */
 export class DdSdkReactNative {
+
+    private static readonly DD_SOURCE_KEY = "_dd.source";
+
     private static wasInitialized = false
 
     /**
@@ -30,6 +33,8 @@ export class DdSdkReactNative {
                 resolve()
                 return
             }
+
+            configuration.additionalConfig[this.DD_SOURCE_KEY] = 'react-native';
 
             DdSdk.initialize(
                 new DdSdkConfiguration(

--- a/src/DdSdkReactNativeConfiguration.tsx
+++ b/src/DdSdkReactNativeConfiguration.tsx
@@ -10,10 +10,10 @@
  */
 export class DdSdkReactNativeConfiguration {
 
-    public nativeCrashReportEnabled: boolean = false
-    public sampleRate: number = 100.0
-    // eslint-disable-next-line @typescript-eslint/ban-types
-    public additionalConfig: object = {}
+    public nativeCrashReportEnabled: boolean = false;
+    public sampleRate: number = 100.0;
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    public additionalConfig: {[k: string]: any} = {};
 
     constructor(
         readonly clientToken: string,

--- a/src/__tests__/DdSdkReactNative.test.tsx
+++ b/src/__tests__/DdSdkReactNative.test.tsx
@@ -7,6 +7,7 @@
 import { NativeModules } from 'react-native'
 import { DdSdkReactNativeConfiguration } from '../DdSdkReactNativeConfiguration'
 import type { DdSdkConfiguration } from '../types'
+import { DdSdk } from '../dd-foundation'
 import { DdSdkReactNative } from '../DdSdkReactNative'
 import { DdRumUserInteractionTracking } from '../rum/instrumentation/DdRumUserInteractionTracking'
 import { DdRumResourceTracking } from '../rum/instrumentation/DdRumResourceTracking'
@@ -16,8 +17,9 @@ jest.mock('react-native', () => {
     return {
         NativeModules: {
             DdSdk: {
-                // eslint-disable-next-line @typescript-eslint/no-empty-function
-                initialize: jest.fn().mockImplementation(() => { })
+                initialize: jest.fn().mockImplementation(() => { }),
+                setUser: jest.fn().mockImplementation(() => { }),
+                setAttributes: jest.fn().mockImplementation(() => { })
             }
         }
     };
@@ -50,6 +52,8 @@ jest.mock('../rum/instrumentation/DdRumErrorTracking', () => {
 beforeEach(async () => {
     DdSdkReactNative['wasInitialized'] = false;
     NativeModules.DdSdk.initialize.mockReset()
+    NativeModules.DdSdk.setAttributes.mockReset()
+    NativeModules.DdSdk.setUser.mockReset()
 })
 
 it('M initialize the SDK W initialize', async () => {
@@ -161,4 +165,30 @@ it('M enable error tracking feature W initialize { error tracking config enabled
         '_dd.source': 'react-native'
     })
     expect(DdRumErrorTracking.startTracking).toHaveBeenCalledTimes(1)
+})
+
+it('M call SDK method W setAttributes', async () => {
+    // GIVEN
+    const attributes = { "foo": "bar" }
+
+    // WHEN
+
+    DdSdkReactNative.setAttributes(attributes)
+
+    // THEN
+    expect(DdSdk.setAttributes).toHaveBeenCalledTimes(1)
+    expect(DdSdk.setAttributes).toHaveBeenCalledWith(attributes)
+})
+
+it('M call SDK method W setUser', async () => {
+    // GIVEN
+    const user = { "foo": "bar" }
+
+    // WHEN
+
+    DdSdkReactNative.setUser(user)
+
+    // THEN
+    expect(DdSdk.setUser).toHaveBeenCalledTimes(1)
+    expect(DdSdk.setUser).toHaveBeenCalledWith(user)
 })

--- a/src/__tests__/DdSdkReactNative.test.tsx
+++ b/src/__tests__/DdSdkReactNative.test.tsx
@@ -64,10 +64,13 @@ it('M initialize the SDK W initialize', async () => {
 
     // THEN
     expect(NativeModules.DdSdk.initialize.mock.calls.length).toBe(1);
-    const ddsdkConfiguration = NativeModules.DdSdk.initialize.mock.calls[0][0] as DdSdkConfiguration
-    expect(ddsdkConfiguration.clientToken).toBe(fakeClientToken)
-    expect(ddsdkConfiguration.applicationId).toBe(fakeAppId)
-    expect(ddsdkConfiguration.env).toBe(fakeEnvName)
+    const ddSdkConfiguration = NativeModules.DdSdk.initialize.mock.calls[0][0] as DdSdkConfiguration
+    expect(ddSdkConfiguration.clientToken).toBe(fakeClientToken)
+    expect(ddSdkConfiguration.applicationId).toBe(fakeAppId)
+    expect(ddSdkConfiguration.env).toBe(fakeEnvName)
+    expect(ddSdkConfiguration.additionalConfig).toStrictEqual({
+        '_dd.source': 'react-native'
+    })
 })
 
 it('M initialize once W initialize { multiple times in a row }', async () => {
@@ -85,10 +88,13 @@ it('M initialize once W initialize { multiple times in a row }', async () => {
 
     // THEN
     expect(NativeModules.DdSdk.initialize.mock.calls.length).toBe(1);
-    const ddsdkConfiguration = NativeModules.DdSdk.initialize.mock.calls[0][0] as DdSdkConfiguration
-    expect(ddsdkConfiguration.clientToken).toBe(fakeClientToken)
-    expect(ddsdkConfiguration.applicationId).toBe(fakeAppId)
-    expect(ddsdkConfiguration.env).toBe(fakeEnvName)
+    const ddSdkConfiguration = NativeModules.DdSdk.initialize.mock.calls[0][0] as DdSdkConfiguration
+    expect(ddSdkConfiguration.clientToken).toBe(fakeClientToken)
+    expect(ddSdkConfiguration.applicationId).toBe(fakeAppId)
+    expect(ddSdkConfiguration.env).toBe(fakeEnvName)
+    expect(ddSdkConfiguration.additionalConfig).toStrictEqual({
+        '_dd.source': 'react-native'
+    })
 })
 
 it('M enable user interaction feature W initialize { user interaction config enabled }', async () => {
@@ -103,10 +109,13 @@ it('M enable user interaction feature W initialize { user interaction config ena
 
     // THEN
     expect(NativeModules.DdSdk.initialize.mock.calls.length).toBe(1);
-    const ddsdkConfiguration = NativeModules.DdSdk.initialize.mock.calls[0][0] as DdSdkConfiguration
-    expect(ddsdkConfiguration.clientToken).toBe(fakeClientToken)
-    expect(ddsdkConfiguration.applicationId).toBe(fakeAppId)
-    expect(ddsdkConfiguration.env).toBe(fakeEnvName)
+    const ddSdkConfiguration = NativeModules.DdSdk.initialize.mock.calls[0][0] as DdSdkConfiguration
+    expect(ddSdkConfiguration.clientToken).toBe(fakeClientToken)
+    expect(ddSdkConfiguration.applicationId).toBe(fakeAppId)
+    expect(ddSdkConfiguration.env).toBe(fakeEnvName)
+    expect(ddSdkConfiguration.additionalConfig).toStrictEqual({
+        '_dd.source': 'react-native'
+    })
     expect(DdRumUserInteractionTracking.startTracking).toHaveBeenCalledTimes(1)
 })
 
@@ -122,10 +131,13 @@ it('M enable resource tracking feature W initialize { resource tracking config e
 
     // THEN
     expect(NativeModules.DdSdk.initialize.mock.calls.length).toBe(1);
-    const ddsdkConfiguration = NativeModules.DdSdk.initialize.mock.calls[0][0] as DdSdkConfiguration
-    expect(ddsdkConfiguration.clientToken).toBe(fakeClientToken)
-    expect(ddsdkConfiguration.applicationId).toBe(fakeAppId)
-    expect(ddsdkConfiguration.env).toBe(fakeEnvName)
+    const ddSdkConfiguration = NativeModules.DdSdk.initialize.mock.calls[0][0] as DdSdkConfiguration
+    expect(ddSdkConfiguration.clientToken).toBe(fakeClientToken)
+    expect(ddSdkConfiguration.applicationId).toBe(fakeAppId)
+    expect(ddSdkConfiguration.env).toBe(fakeEnvName)
+    expect(ddSdkConfiguration.additionalConfig).toStrictEqual({
+        '_dd.source': 'react-native'
+    })
     expect(DdRumResourceTracking.startTracking).toHaveBeenCalledTimes(1)
 })
 
@@ -141,9 +153,12 @@ it('M enable error tracking feature W initialize { error tracking config enabled
 
     // THEN
     expect(NativeModules.DdSdk.initialize.mock.calls.length).toBe(1);
-    const ddsdkConfiguration = NativeModules.DdSdk.initialize.mock.calls[0][0] as DdSdkConfiguration
-    expect(ddsdkConfiguration.clientToken).toBe(fakeClientToken)
-    expect(ddsdkConfiguration.applicationId).toBe(fakeAppId)
-    expect(ddsdkConfiguration.env).toBe(fakeEnvName)
+    const ddSdkConfiguration = NativeModules.DdSdk.initialize.mock.calls[0][0] as DdSdkConfiguration
+    expect(ddSdkConfiguration.clientToken).toBe(fakeClientToken)
+    expect(ddSdkConfiguration.applicationId).toBe(fakeAppId)
+    expect(ddSdkConfiguration.env).toBe(fakeEnvName)
+    expect(ddSdkConfiguration.additionalConfig).toStrictEqual({
+        '_dd.source': 'react-native'
+    })
     expect(DdRumErrorTracking.startTracking).toHaveBeenCalledTimes(1)
 })

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -4,11 +4,10 @@
  * Copyright 2016-Present Datadog, Inc.
  */
 
-import { DdSdkConfiguration } from './types';
-import { DdSdk, DdLogs, DdTrace, DdRum } from './dd-foundation';
+import { DdLogs, DdTrace, DdRum } from './dd-foundation';
 import DdRumReactNavigationTracking from './rum/instrumentation/DdRumReactNavigationTracking';
 import { DdSdkReactNativeConfiguration } from './DdSdkReactNativeConfiguration';
 import { DdSdkReactNative } from './DdSdkReactNative';
 
 
-export { DdSdkConfiguration, DdSdk, DdLogs, DdTrace, DdRum, DdSdkReactNativeConfiguration, DdSdkReactNative, DdRumReactNavigationTracking };
+export { DdLogs, DdTrace, DdRum, DdSdkReactNativeConfiguration, DdSdkReactNative, DdRumReactNavigationTracking };


### PR DESCRIPTION
### What does this PR do?

This change allows tracking React Native integration as a dedicated source in the RUM Dashboard (+Logs, etc.).

Also it removes `DdSdk` and `DdSdkConfiguration` from publicly exposed members, user should always use `DdSdkReactNative` and `DdSdkReactNativeConfiguration` instead.

### Additional Notes

This PR should be merged after corresponding PR in `dd-bridge-android` repo (https://github.com/DataDog/dd-bridge-android/pull/13). So far I tested it with local deployments of `dd-sdk-android` and `dd-bridge-android` which support `additionalConfig` and it is working fine in the end.

![image](https://user-images.githubusercontent.com/4046447/113313298-672f2b80-930b-11eb-97f2-71b3c08ca7c7.png)

### Review checklist (to be filled by reviewers)

- [x] Feature or bugfix MUST have appropriate tests
- [x] Make sure you discussed the feature or bugfix with the maintaining team in an Issue
- [x] Make sure each commit and the PR mention the Issue number (cf the [CONTRIBUTING](CONTRIBUTING.md) doc)

