### PR TITLE
RUMM-1236: Solve circular dependency warning in the require chain

### DIFF
--- a/src/__tests__/rum/instrumentation/DdEventsInterceptor.test.tsx
+++ b/src/__tests__/rum/instrumentation/DdEventsInterceptor.test.tsx
@@ -7,7 +7,7 @@
 import { DdEventsInterceptor, RumActionType, UNKNOWN_TARGET_NAME } from '../../../rum/instrumentation/DdEventsInterceptor'
 import { DdRum } from '../../../index';
 
-jest.mock('../../../index', () => {
+jest.mock('../../../dd-foundation', () => {
     return {
         DdRum: {
             // eslint-disable-next-line @typescript-eslint/no-empty-function

--- a/src/__tests__/rum/instrumentation/DdRumErrorTracking.test.tsx
+++ b/src/__tests__/rum/instrumentation/DdRumErrorTracking.test.tsx
@@ -9,12 +9,12 @@ import { DdRum } from '../../../index';
 
 jest.useFakeTimers()
 
-jest.mock('../../../index', () => {
+jest.mock('../../../dd-foundation', () => {
     return {
         DdRum: {
             // eslint-disable-next-line @typescript-eslint/no-empty-function
-            addError: jest.fn().mockImplementation(() => { 
-                return new Promise( (resolve, reject) => {
+            addError: jest.fn().mockImplementation(() => {
+                return new Promise((resolve, reject) => {
                     resolve()
                 })
             })

--- a/src/__tests__/rum/instrumentation/DdRumReactNavigationTracking.test.tsx
+++ b/src/__tests__/rum/instrumentation/DdRumReactNavigationTracking.test.tsx
@@ -12,7 +12,7 @@ import DdRumReactNavigationTracking from '../../../rum/instrumentation/DdRumReac
 import { render, fireEvent } from '@testing-library/react-native';
 import { createStackNavigator } from '@react-navigation/stack';
 
-jest.mock('../../../index', () => {
+jest.mock('../../../dd-foundation', () => {
     return {
         DdRum: {
             // eslint-disable-next-line @typescript-eslint/no-empty-function

--- a/src/__tests__/rum/instrumentation/DdRumResourceTracking.test.tsx
+++ b/src/__tests__/rum/instrumentation/DdRumResourceTracking.test.tsx
@@ -9,7 +9,7 @@ import { DdRum } from '../../../index';
 
 jest.useFakeTimers()
 
-jest.mock('../../../index', () => {
+jest.mock('../../../dd-foundation', () => {
     return {
         DdRum: {
             // eslint-disable-next-line @typescript-eslint/no-empty-function

--- a/src/dd-foundation.tsx
+++ b/src/dd-foundation.tsx
@@ -1,0 +1,7 @@
+import type { DdSdkType, DdLogsType, DdTraceType, DdRumType } from './types';
+import { NativeModules } from 'react-native';
+
+export const DdSdk: DdSdkType = NativeModules.DdSdk;
+export const DdLogs: DdLogsType = NativeModules.DdLogs;
+export const DdTrace: DdTraceType = NativeModules.DdTrace;
+export const DdRum: DdRumType = NativeModules.DdRum;

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -4,15 +4,11 @@
  * Copyright 2016-Present Datadog, Inc.
  */
 
-import { NativeModules } from 'react-native';
-import { DdSdkConfiguration, DdSdkType, DdLogsType, DdTraceType, DdRumType } from './types';
+import { DdSdkConfiguration } from './types';
+import { DdSdk, DdLogs, DdTrace, DdRum } from './dd-foundation';
 import DdRumReactNavigationTracking from './rum/instrumentation/DdRumReactNavigationTracking';
 import { DdSdkReactNativeConfiguration } from './DdSdkReactNativeConfiguration';
 import { DdSdkReactNative } from './DdSdkReactNative';
 
-const DdSdk: DdSdkType = NativeModules.DdSdk;
-const DdLogs: DdLogsType = NativeModules.DdLogs;
-const DdTrace: DdTraceType = NativeModules.DdTrace;
-const DdRum: DdRumType = NativeModules.DdRum;
 
 export { DdSdkConfiguration, DdSdk, DdLogs, DdTrace, DdRum, DdSdkReactNativeConfiguration, DdSdkReactNative, DdRumReactNavigationTracking };

--- a/src/rum/instrumentation/DdEventsInterceptor.tsx
+++ b/src/rum/instrumentation/DdEventsInterceptor.tsx
@@ -5,7 +5,7 @@
  */
 
 import type EventsInterceptor from './EventsInterceptor'
-import { DdRum } from '../../index'
+import { DdRum } from '../../dd-foundation'
 
 export const UNKNOWN_TARGET_NAME = "unknown_target"
 const DEBOUNCE_EVENT_THRESHOLD_IN_MS = 10

--- a/src/rum/instrumentation/DdRumErrorTracking.tsx
+++ b/src/rum/instrumentation/DdRumErrorTracking.tsx
@@ -4,7 +4,7 @@
  * Copyright 2016-Present Datadog, Inc.
  */
 
-import { DdRum } from '../../index';
+import { DdRum } from '../../dd-foundation';
 
 
 const EMPTY_STACK_TRACE = ""

--- a/src/rum/instrumentation/DdRumReactNavigationTracking.tsx
+++ b/src/rum/instrumentation/DdRumReactNavigationTracking.tsx
@@ -5,7 +5,7 @@
  */
 
 import type { EventArg, NavigationContainerRef, Route } from "@react-navigation/native";
-import { DdRum } from '../../index';
+import { DdRum } from '../../dd-foundation';
 import { AppState, AppStateStatus } from 'react-native';
 
 // eslint-disable-next-line @typescript-eslint/no-explicit-any

--- a/src/rum/instrumentation/DdRumResourceTracking.tsx
+++ b/src/rum/instrumentation/DdRumResourceTracking.tsx
@@ -4,7 +4,7 @@
  * Copyright 2016-Present Datadog, Inc.
  */
 
-import { DdRum } from '../../index'
+import { DdRum } from '../../dd-foundation'
 import type { DdRumXhr } from './DdRumXhr'
 import { generateTraceId } from './TraceIdentifier';
 


### PR DESCRIPTION
### What does this PR do?

Follow-up on #30. This change solved circular dependency warning in the `require` chain by extracting core DD SDK classes in the dedicated module.

### Review checklist (to be filled by reviewers)

- [x] Feature or bugfix MUST have appropriate tests
- [x] Make sure you discussed the feature or bugfix with the maintaining team in an Issue
- [x] Make sure each commit and the PR mention the Issue number (cf the [CONTRIBUTING](CONTRIBUTING.md) doc)

