### PR TITLE
RUMM-1308/improve errors

### DIFF
--- a/example/android/app/build.gradle
+++ b/example/android/app/build.gradle
@@ -77,6 +77,8 @@ import com.android.build.OutputFile
 
 project.ext.react = [
     enableHermes: false,  // clean and rebuild if changing
+    // the entry file for bundle generation
+    entryFile: "index.tsx",
 ]
 
 apply from: "../../node_modules/react-native/react.gradle"

--- a/example/src/screens/AboutScreen.tsx
+++ b/example/src/screens/AboutScreen.tsx
@@ -1,5 +1,5 @@
 import React, {Component} from 'react';
-import { View, Text } from 'react-native';
+import { View, Text, TouchableNativeFeedback } from 'react-native';
 import styles from './styles';
 import {about} from '../resources/strings.json';
 
@@ -8,6 +8,15 @@ export default class AboutScreen extends Component<any, any> {
     render(){
        return <View style={styles.defaultScreen}>
          <Text>Result: {about} </Text>
+         <TouchableNativeFeedback
+          accessibilityLabel="click_me_about"
+          onPress={() => {
+            console.error("Not implemented", Error("Oups"));
+          }}>
+          <View style={styles.button}>
+            <Text>Click me</Text>
+          </View>
+        </TouchableNativeFeedback>
       </View>
     }
 }

--- a/src/__tests__/rum/instrumentation/DdRumErrorTracking.test.tsx
+++ b/src/__tests__/rum/instrumentation/DdRumErrorTracking.test.tsx
@@ -50,6 +50,7 @@ beforeEach(() => {
 afterEach(() => {
     DdRumErrorTracking['isTracking'] = false
     ErrorUtils.setGlobalHandler(originalErrorHandler)
+    console.error = originalConsoleError
 })
 
 
@@ -134,7 +135,7 @@ it('M intercept and send a RUM event W onConsole() {Error with source file info}
       sourceURL: "./path/to/file.js",
       line: 1038,
       column: 57,
-      message: "Something bad happened"
+      message: message
     };
 
     // WHEN

--- a/src/__tests__/rum/instrumentation/DdRumErrorTracking.test.tsx
+++ b/src/__tests__/rum/instrumentation/DdRumErrorTracking.test.tsx
@@ -29,6 +29,12 @@ let baseErrorHandler = (error: any, isFatal?: boolean) => {
 };
 let originalErrorHandler = undefined;
 
+let baseConsoleErrorCalled = false;
+let baseConsoleError = (...params: unknown) => {
+    baseConsoleErrorCalled = true
+}
+let originalConsoleError = undefined
+
 const flushPromises = () => new Promise(setImmediate);
 
 beforeEach(() => {
@@ -36,6 +42,8 @@ beforeEach(() => {
     baseErrorHandlerCalled = false;
     originalErrorHandler = ErrorUtils.getGlobalHandler();
     ErrorUtils.setGlobalHandler(baseErrorHandler);
+    originalConsoleError = console.error;
+    console.error = baseConsoleError;
     jest.setTimeout(20000)
 })
 
@@ -45,13 +53,14 @@ afterEach(() => {
 })
 
 
-it('M intercept and send a RUM event W onError() {empty stack trace}', async () => {
+it('M intercept and send a RUM event W onGlobalError() {empty stack trace}', async () => {
     // GIVEN
-    DdRumErrorTracking.startTracking()
+    DdRumErrorTracking.startTracking();
+    const is_fatal = Math.random() < 0.5;
     const error = new Error('Something bad happened');
 
     // WHEN
-    DdRumErrorTracking.onError(error, false);
+    DdRumErrorTracking.onGlobalError(error, is_fatal);
     await flushPromises();
 
     // THEN
@@ -59,14 +68,17 @@ it('M intercept and send a RUM event W onError() {empty stack trace}', async () 
     expect(DdRum.addError.mock.calls[0][0]).toBe(String(error));
     expect(DdRum.addError.mock.calls[0][1]).toBe("SOURCE");
     expect(DdRum.addError.mock.calls[0][2]).toBe("");
-    expect(DdRum.addError.mock.calls[0][4]).toStrictEqual(error);
+    const attributes = DdRum.addError.mock.calls[0][4];
+    expect(attributes["_dd.error.raw"]).toStrictEqual(error);
+    expect(attributes["_dd.error.is_crash"]).toStrictEqual(is_fatal);
     expect(baseErrorHandlerCalled).toStrictEqual(true);
 })
 
 
-it('M intercept and send a RUM event W onError() {with source file info}', async () => {
+it('M intercept and send a RUM event W onGlobalError() {with source file info}', async () => {
     // GIVEN
-    DdRumErrorTracking.startTracking()
+    DdRumErrorTracking.startTracking();
+    const is_fatal = Math.random() < 0.5;
     const error = {
       sourceURL: "./path/to/file.js",
       line: 1038,
@@ -75,7 +87,7 @@ it('M intercept and send a RUM event W onError() {with source file info}', async
     };
 
     // WHEN
-    DdRumErrorTracking.onError(error, false);
+    DdRumErrorTracking.onGlobalError(error, is_fatal);
     await flushPromises();
 
     // THEN
@@ -83,21 +95,24 @@ it('M intercept and send a RUM event W onError() {with source file info}', async
     expect(DdRum.addError.mock.calls[0][0]).toBe(String(error));
     expect(DdRum.addError.mock.calls[0][1]).toBe("SOURCE");
     expect(DdRum.addError.mock.calls[0][2]).toBe("at ./path/to/file.js:1038:57");
-    expect(DdRum.addError.mock.calls[0][4]).toStrictEqual(error);
+    const attributes = DdRum.addError.mock.calls[0][4];
+    expect(attributes["_dd.error.raw"]).toStrictEqual(error);
+    expect(attributes["_dd.error.is_crash"]).toStrictEqual(is_fatal);
     expect(baseErrorHandlerCalled).toStrictEqual(true);
 })
 
 
-it('M intercept and send a RUM event W onError() {with component stack}', async () => {
+it('M intercept and send a RUM event W onGlobalError() {with component stack}', async () => {
     // GIVEN
-    DdRumErrorTracking.startTracking()
+    DdRumErrorTracking.startTracking();
+    const is_fatal = Math.random() < 0.5;
     const error = {
       componentStack: ["doSomething() at ./path/to/file.js:67:3", "nestedCall() at ./path/to/file.js:1064:9", "root() at ./path/to/index.js:10:1"],
       message: "Something bad happened"
     };
 
     // WHEN
-    DdRumErrorTracking.onError(error, false);
+    DdRumErrorTracking.onGlobalError(error, is_fatal);
     await flushPromises();
 
     // THEN
@@ -105,7 +120,72 @@ it('M intercept and send a RUM event W onError() {with component stack}', async 
     expect(DdRum.addError.mock.calls[0][0]).toBe(String(error));
     expect(DdRum.addError.mock.calls[0][1]).toBe("SOURCE");
     expect(DdRum.addError.mock.calls[0][2]).toBe("doSomething() at ./path/to/file.js:67:3,nestedCall() at ./path/to/file.js:1064:9,root() at ./path/to/index.js:10:1");
-    expect(DdRum.addError.mock.calls[0][4]).toStrictEqual(error);
+    const attributes = DdRum.addError.mock.calls[0][4];
+    expect(attributes["_dd.error.raw"]).toStrictEqual(error);
+    expect(attributes["_dd.error.is_crash"]).toStrictEqual(is_fatal);
     expect(baseErrorHandlerCalled).toStrictEqual(true);
 })
 
+it('M intercept and send a RUM event W onConsole() {Error with source file info}', async () => {
+    // GIVEN
+    DdRumErrorTracking.startTracking();
+    const message= "Something bad happened";
+    const error = {
+      sourceURL: "./path/to/file.js",
+      line: 1038,
+      column: 57,
+      message: "Something bad happened"
+    };
+
+    // WHEN
+    DdRumErrorTracking.onConsoleError(message, error);
+    await flushPromises();
+
+    // THEN
+    expect(DdRum.addError.mock.calls.length).toBe(1);
+    expect(DdRum.addError.mock.calls[0][0]).toBe(message + " " + JSON.stringify(error));
+    expect(DdRum.addError.mock.calls[0][1]).toBe("CONSOLE");
+    expect(DdRum.addError.mock.calls[0][2]).toBe("at ./path/to/file.js:1038:57");
+    expect(DdRum.addError.mock.calls[0][4]).toStrictEqual({})
+    expect(baseConsoleErrorCalled).toStrictEqual(true);
+})
+
+it('M intercept and send a RUM event W onConsole() {Error with component stack}', async () => {
+    // GIVEN
+    DdRumErrorTracking.startTracking();
+    const message= "Something bad happened";
+    const error = {
+      componentStack: ["doSomething() at ./path/to/file.js:67:3", "nestedCall() at ./path/to/file.js:1064:9", "root() at ./path/to/index.js:10:1"],
+      message: "Something bad happened"
+    };
+
+    // WHEN
+    DdRumErrorTracking.onConsoleError(message, error);
+    await flushPromises();
+
+    // THEN
+    expect(DdRum.addError.mock.calls.length).toBe(1);
+    expect(DdRum.addError.mock.calls[0][0]).toBe(message + " " + JSON.stringify(error));
+    expect(DdRum.addError.mock.calls[0][1]).toBe("CONSOLE");
+    expect(DdRum.addError.mock.calls[0][2]).toBe("doSomething() at ./path/to/file.js:67:3,nestedCall() at ./path/to/file.js:1064:9,root() at ./path/to/index.js:10:1");
+    expect(DdRum.addError.mock.calls[0][4]).toStrictEqual({})
+    expect(baseConsoleErrorCalled).toStrictEqual(true);
+})
+
+it('M intercept and send a RUM event W onConsole() {message only}', async () => {
+    // GIVEN
+    DdRumErrorTracking.startTracking();
+    const message= "Something bad happened";
+
+    // WHEN
+    DdRumErrorTracking.onConsoleError(message);
+    await flushPromises();
+
+    // THEN
+    expect(DdRum.addError.mock.calls.length).toBe(1);
+    expect(DdRum.addError.mock.calls[0][0]).toBe(message);
+    expect(DdRum.addError.mock.calls[0][1]).toBe("CONSOLE");
+    expect(DdRum.addError.mock.calls[0][2]).toBe("");
+    expect(DdRum.addError.mock.calls[0][4]).toStrictEqual({})
+    expect(baseConsoleErrorCalled).toStrictEqual(true);
+})

--- a/src/rum/instrumentation/DdRumErrorTracking.tsx
+++ b/src/rum/instrumentation/DdRumErrorTracking.tsx
@@ -93,13 +93,13 @@ export class DdRumErrorTracking {
     private static getErrorStackTrace(error: any | undefined): string {
         let stack = EMPTY_STACK_TRACE
         if (error == undefined) {
-            stack = EMPTY_STACK_TRACE
+            stack = EMPTY_STACK_TRACE;
         } else if (typeof error === 'string') {
-            stack = EMPTY_STACK_TRACE
+            stack = EMPTY_STACK_TRACE;
         } else if ('componentStack' in error) {
             stack = String(error.componentStack);
         } else if (('sourceURL' in error) && ('line' in error) && ('column' in error)) {
-            stack = "at " + error.sourceURL + ":" + error.line + ":" + error.column
+            stack = `at ${error.sourceURL}:${error.line}:${error.column}`;
         }
         return stack
     }

--- a/src/rum/instrumentation/DdRumErrorTracking.tsx
+++ b/src/rum/instrumentation/DdRumErrorTracking.tsx
@@ -9,6 +9,7 @@ import { DdRum } from '../../dd-foundation';
 
 const EMPTY_STACK_TRACE = ""
 const TYPE_SOURCE = "SOURCE"
+const TYPE_CONSOLE = "CONSOLE"
 
 /**
 * Provides RUM auto-instrumentation feature to track errors as RUM events.
@@ -20,39 +21,87 @@ export class DdRumErrorTracking {
     // eslint-disable-next-line 
     private static defaultErrorHandler = (_error: any, _isFatal?: boolean) => {}
 
+    // eslint-disable-next-line 
+    private static defaultConsoleError = (..._params: unknown[]) => {}
+
     /**
      * Starts tracking errors and sends a RUM Error event every time an error is detected.
      */
     static startTracking(): void {
         // extra safety to avoid wrapping the Error handler twice
-        if (this.isTracking) {
+        if (DdRumErrorTracking.isTracking) {
+            console.log("DdRumErrorTracking already started");
             return
         }
         
         if (ErrorUtils) {
-            this.defaultErrorHandler = ErrorUtils.getGlobalHandler();
+            DdRumErrorTracking.defaultErrorHandler = ErrorUtils.getGlobalHandler();
+            DdRumErrorTracking.defaultConsoleError = console.error;
 
-            ErrorUtils.setGlobalHandler(this.onError);
+            
+            ErrorUtils.setGlobalHandler(DdRumErrorTracking.onGlobalError);
+            console.error = DdRumErrorTracking.onConsoleError;
 
-            this.isTracking = true;
+            DdRumErrorTracking.isTracking = true;
         }
 
     }
 
     // eslint-disable-next-line 
-    static onError(error: any, isFatal?: boolean) {
-        // Stack trace
-        let stack = EMPTY_STACK_TRACE
-        if (error.hasOwnProperty('componentStack')) {
-            stack = String(error.componentStack);
-        } else if (error.hasOwnProperty('sourceURL') && error.hasOwnProperty('line') && error.hasOwnProperty('column')) {
-            stack = "at " + error.sourceURL + ":" + error.line + ":" + error.column
-        }
-
-        DdRum.addError(String(error), TYPE_SOURCE, stack, new Date().getTime(), error).then(() => {
-            this.defaultErrorHandler(error, isFatal)
+    static onGlobalError(error: any, isFatal?: boolean) {
+        DdRum.addError(
+            String(error), 
+            TYPE_SOURCE, 
+            DdRumErrorTracking.getErrorStackTrace(error), 
+            new Date().getTime(), 
+            { "_dd.error.is_crash": isFatal, "_dd.error.raw": error }
+        ).then(() => {
+            DdRumErrorTracking.defaultErrorHandler(error, isFatal);
         });
     }
 
+    static onConsoleError(...params: unknown[]) {
+        let stack: string = EMPTY_STACK_TRACE
+        for (let i = 0; i < params.length; i += 1) {
+            const param = params[i];
+            const paramStack = DdRumErrorTracking.getErrorStackTrace(param)
+            if (paramStack != undefined && paramStack != EMPTY_STACK_TRACE){
+                stack = paramStack;
+                break;
+            }
+        }
+
+        const message = params.map((param) => {
+            if (typeof param === 'string') { return param }
+            else if (param instanceof Error) { return String(param) }
+            else { return JSON.stringify(param)}
+        }).join(' ');
+
+        
+        DdRum.addError(
+            message, 
+            TYPE_CONSOLE,
+            stack, 
+            new Date().getTime(), 
+            {}
+        ).then(() => {
+            DdRumErrorTracking.defaultConsoleError.apply(console, params);
+        });
+        
+    }
+
+    private static getErrorStackTrace(error: any | undefined): string {
+        let stack = EMPTY_STACK_TRACE
+        if (error == undefined) {
+            stack = EMPTY_STACK_TRACE
+        } else if (typeof error === 'string') {
+            stack = EMPTY_STACK_TRACE
+        } else if ('componentStack' in error) {
+            stack = String(error.componentStack);
+        } else if (('sourceURL' in error) && ('line' in error) && ('column' in error)) {
+            stack = "at " + error.sourceURL + ":" + error.line + ":" + error.column
+        }
+        return stack
+    }
 }
 

--- a/src/rum/instrumentation/DdRumReactNavigationTracking.tsx
+++ b/src/rum/instrumentation/DdRumReactNavigationTracking.tsx
@@ -34,16 +34,16 @@ export default class DdRumReactNavigationTracking {
             return;
         }
 
-        if (this.registeredContainer != null && this.registeredContainer !== navigationRef) {
+        if (DdRumReactNavigationTracking.registeredContainer != null && this.registeredContainer !== navigationRef) {
             console.error('Cannot track new navigation container while another one is still tracked');
-        } else if (this.registeredContainer == null) {
-            const listener = this.resolveNavigationStateChangeListener();
-            this.handleRouteNavigation(navigationRef.getCurrentRoute());
+        } else if (DdRumReactNavigationTracking.registeredContainer == null) {
+            const listener = DdRumReactNavigationTracking.resolveNavigationStateChangeListener();
+            DdRumReactNavigationTracking.handleRouteNavigation(navigationRef.getCurrentRoute());
             navigationRef.addListener("state", listener);
-            this.registeredContainer = navigationRef;
+            DdRumReactNavigationTracking.registeredContainer = navigationRef;
         }
 
-        this.registerAppStateListenerIfNeeded();
+        DdRumReactNavigationTracking.registerAppStateListenerIfNeeded();
     }
 
     /**
@@ -52,8 +52,8 @@ export default class DdRumReactNavigationTracking {
      */
     static stopTrackingViews(navigationRef: NavigationContainerRef | null): void {
         if (navigationRef != null) {
-            navigationRef.removeListener("state", this.navigationStateChangeListener);
-            this.registeredContainer = null;
+            navigationRef.removeListener("state", DdRumReactNavigationTracking.navigationStateChangeListener);
+            DdRumReactNavigationTracking.registeredContainer = null;
         }
     }
 
@@ -67,25 +67,25 @@ export default class DdRumReactNavigationTracking {
     }
 
     private static resolveNavigationStateChangeListener(): NavigationListener {
-        if (this.navigationStateChangeListener == null) {
+        if (DdRumReactNavigationTracking.navigationStateChangeListener == null) {
             // eslint-disable-next-line @typescript-eslint/no-explicit-any
-            this.navigationStateChangeListener = (event: EventArg<string, boolean, any>) => {
+            DdRumReactNavigationTracking.navigationStateChangeListener = (event: EventArg<string, boolean, any>) => {
                 let nestedRoute = event.data?.state?.routes[event.data?.state?.index];
                 while (nestedRoute.state != undefined) {
                     nestedRoute = nestedRoute.state.routes[nestedRoute.state.index];
                 }
 
-                this.handleRouteNavigation(nestedRoute);
+                DdRumReactNavigationTracking.handleRouteNavigation(nestedRoute);
             };
         }
-        return this.navigationStateChangeListener;
+        return DdRumReactNavigationTracking.navigationStateChangeListener;
     }
 
     private static registerAppStateListenerIfNeeded() {
-        if (this.appStateListener == null) {
-            this.appStateListener = (appStateStatus: AppStateStatus) => {
+        if (DdRumReactNavigationTracking.appStateListener == null) {
+            DdRumReactNavigationTracking.appStateListener = (appStateStatus: AppStateStatus) => {
 
-                const currentRoute = this.registeredContainer?.getCurrentRoute();
+                const currentRoute = DdRumReactNavigationTracking.registeredContainer?.getCurrentRoute();
                 const currentViewKey = currentRoute?.key;
                 const currentViewName = currentRoute?.name;
 
@@ -101,7 +101,7 @@ export default class DdRumReactNavigationTracking {
             };
 
             // AppState is singleton, so we should add a listener only once in the app lifetime
-            AppState.addEventListener("change", this.appStateListener);
+            AppState.addEventListener("change", DdRumReactNavigationTracking.appStateListener);
         }
     }
 

--- a/src/rum/instrumentation/DdRumResourceTracking.tsx
+++ b/src/rum/instrumentation/DdRumResourceTracking.tsx
@@ -29,7 +29,7 @@ export class DdRumResourceTracking {
   * Starts tracking resources and sends a RUM Resource event every time a network request is detected.
   */
   static startTracking(): void {
-    this.startTrackingInternal(XMLHttpRequest);
+    DdRumResourceTracking.startTrackingInternal(XMLHttpRequest);
   }
 
   /**
@@ -38,22 +38,22 @@ export class DdRumResourceTracking {
   // eslint-disable-next-line @typescript-eslint/no-explicit-any,@typescript-eslint/explicit-module-boundary-types
   static startTrackingInternal(xhrType: any): void {
     // extra safety to avoid proxying the XHR class twice
-    if (this.isTracking) {
+    if (DdRumResourceTracking.isTracking) {
       return
     }
 
-    this.originalXhrOpen = xhrType.prototype.open;
-    this.originalXhrSend = xhrType.prototype.send;
+    DdRumResourceTracking.originalXhrOpen = xhrType.prototype.open;
+    DdRumResourceTracking.originalXhrSend = xhrType.prototype.send;
 
-    this.proxyXhr(xhrType)
+    DdRumResourceTracking.proxyXhr(xhrType)
   }
 
 
   static stopTracking(): void {
-    if (this.isTracking) {
-      this.isTracking = false;
-      XMLHttpRequest.prototype.open = this.originalXhrOpen;
-      XMLHttpRequest.prototype.send = this.originalXhrSend;
+    if (DdRumResourceTracking.isTracking) {
+      DdRumResourceTracking.isTracking = false;
+      XMLHttpRequest.prototype.open = DdRumResourceTracking.originalXhrOpen;
+      XMLHttpRequest.prototype.send = DdRumResourceTracking.originalXhrSend;
     }
   }
 

--- a/src/rum/instrumentation/DdRumUserInteractionTracking.tsx
+++ b/src/rum/instrumentation/DdRumUserInteractionTracking.tsx
@@ -28,10 +28,10 @@ export class DdRumUserInteractionTracking {
      */
     static startTracking(): void {
         // extra safety to avoid wrapping more than 1 time this function
-        if (this.isTracking) {
+        if (DdRumUserInteractionTracking.isTracking) {
             return
         }
-        this.eventsInterceptor = new DdEventsInterceptor()
+        DdRumUserInteractionTracking.eventsInterceptor = new DdEventsInterceptor()
         const original = React.createElement
         // eslint-disable-next-line @typescript-eslint/no-explicit-any
         React.createElement = (element: any, props: any, ...children: any): any => {
@@ -40,13 +40,13 @@ export class DdRumUserInteractionTracking {
                 const originalOnPress = props.onPress
                 // eslint-disable-next-line @typescript-eslint/no-explicit-any
                 props.onPress = (...args: any[]) => {
-                    this.eventsInterceptor.interceptOnPress(args)
+                    DdRumUserInteractionTracking.eventsInterceptor.interceptOnPress(args)
                     return originalOnPress(...args)
                 }
             }
             return original(element, props, ...children)
         }
-        this.isTracking = true
+        DdRumUserInteractionTracking.isTracking = true
     }
 
 }


### PR DESCRIPTION
### What does this PR do?

Improve our error handling, and add support to tracking console errors.
For error handling, we add two internal params: 
- `_dd.error.is_crash` that maps the `is_fatal` parameter. This should be used by our native SDKs to appropriately tag the related RUM Error
- `_dd.error.raw` that holds the raw error object. 


### Additional Notes

Remove usage of this for static methods: There was a big issue in our Typescript code, we referenced `this` in many places from static methods. Problem is that in a static method, `this` is always `undefined` meaning we were losing a lot of references :/