### PR TITLE
Add a possibility to enable/disable Hermes JS engine

### DIFF
--- a/example/android/app/build.gradle
+++ b/example/android/app/build.gradle
@@ -212,7 +212,13 @@ dependencies {
         exclude group:'com.facebook.flipper'
     }
 
-    implementation jscFlavor
+    if (enableHermes) {
+        def hermesPath = "../../node_modules/hermes-engine/android/";
+        debugImplementation files(hermesPath + "hermes-debug.aar")
+        releaseImplementation files(hermesPath + "hermes-release.aar")
+    } else {
+        implementation jscFlavor
+    }
 
     implementation 'androidx.multidex:multidex:2.0.1'
 }


### PR DESCRIPTION
### What does this PR do?

This changed adds a possibility to enable/disable Hermes JS engine in the final app, which may be needed to debug customer issues. Hermes is disabled by default.

