### PR TITLE
Remove Bintray repo reference

### DIFF
--- a/example/android/app/build.gradle
+++ b/example/android/app/build.gradle
@@ -188,7 +188,6 @@ android {
 }
 
 repositories {
-    maven { url "https://dl.bintray.com/datadog/datadog-maven" }
     maven {
         // Android JSC is installed from npm
         url("$rootDir/../node_modules/jsc-android/dist")


### PR DESCRIPTION
### What does this PR do?

This change removes Bintray repo reference since it is not working anymore.