### PR TITLE
RUMM-1496: Make context and timestamp arguments optional

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -3,4 +3,7 @@ example
 dist
 lib
 packages/**/src/types.tsx
+// TODO remove that line once bridges updated
+// with proper order of context and timestamp
+packages/**/src/foundation.tsx
 packages/**/src/__tests__

--- a/README.md
+++ b/README.md
@@ -154,38 +154,38 @@ const config = new DdSdkReactNativeConfiguration(
 DdSdkReactNative.initialize(config);
 
 // Send logs (use the debug, info, warn or error methods)
-DdLogs.debug("Lorem ipsum dolor sit amet…", 0, {});
-DdLogs.info("Lorem ipsum dolor sit amet…", 0, {});
-DdLogs.warn("Lorem ipsum dolor sit amet…", 0, {});
-DdLogs.error("Lorem ipsum dolor sit amet…", 0, {});
+DdLogs.debug("Lorem ipsum dolor sit amet…", {});
+DdLogs.info("Lorem ipsum dolor sit amet…", {});
+DdLogs.warn("Lorem ipsum dolor sit amet…", {});
+DdLogs.error("Lorem ipsum dolor sit amet…", {});
 
 // Track RUM Views manually
-DdRum.startView('<view-key>', 'View Url', Date.now(), {});
+DdRum.startView('<view-key>', 'View Url', {}, Date.now());
 //…
-DdRum.stopView('<view-key>', Date.now(), { 'custom': 42 });
+DdRum.stopView('<view-key>', { 'custom': 42 }, Date.now());
 
 // Track RUM Actions manually
-DdRum.addAction('TAP', 'button name', Date.now(), {});
+DdRum.addAction('TAP', 'button name', {}, Date.now());
 // or in case of continuous action
-DdRum.startAction('TAP', 'button name', Date.now(), {});
+DdRum.startAction('TAP', 'button name', {}, Date.now());
 // to stop action above
-DdRum.stopAction(Date.now(), {});
+DdRum.stopAction({}, Date.now());
 
 // Add custom timings
 DdRum.addTiming('<timing-name>');
 
 // Track RUM Errors manually
-DdRum.addError('<message>', 'source', '<stacktrace>', Date.now(), {});
+DdRum.addError('<message>', 'source', '<stacktrace>', {}, Date.now());
 
 // Track RUM Resource manually
-DdRum.startResource('<res-key>', 'GET', 'http://www.example.com/api/v1/test', Date.now(), {} );
+DdRum.startResource('<res-key>', 'GET', 'http://www.example.com/api/v1/test', {}, Date.now());
 //…
-DdRum.stopResource('<res-key>', 200, 'xhr', Date.now(), {});
+DdRum.stopResource('<res-key>', 200, 'xhr', {}, Date.now());
 
 // Send spans manually
-const spanId = await DdTrace.startSpan("foo", Date.now(), { 'custom': 42 });
+const spanId = await DdTrace.startSpan("foo", { 'custom': 42 }, Date.now());
 //...
-DdTrace.finishSpan(spanId, Date.now(), { 'custom': 21 });
+DdTrace.finishSpan(spanId, { 'custom': 21 }, Date.now());
 ```
 
 ## Resource timings

--- a/example/src/ddUtils.tsx
+++ b/example/src/ddUtils.tsx
@@ -23,7 +23,7 @@ export function initializeDatadog(trackingConsent: TrackingConsent) {
     config.sampleRate = 100
 
     DdSdkReactNative.initialize(config).then(() => {
-        DdLogs.info('The RN Sdk was properly initialized', {})
+        DdLogs.info('The RN Sdk was properly initialized')
         DdSdkReactNative.setUser({id: "1337", name: "Xavier", email: "xg@example.com", type: "premium"})
         DdSdkReactNative.setAttributes({campaign: "ad-network"})
     });

--- a/packages/core/README.md
+++ b/packages/core/README.md
@@ -63,9 +63,9 @@ Because React Native offers a wide range of libraries to create screen navigatio
 import { DdSdkReactNative, DdSdkReactNativeConfiguration, DdLogs, DdRum } from '@datadog/mobile-react-native';
 
 
-// Start a view with a unique view identifier, a custom view url, and an object to attach additional attribtutes to the view
+// Start a view with a unique view identifier, a custom view url, and an object to attach additional attributes to the view
 DdRum.startView('<view-key>', '/view/url', Date.now(), { 'custom.foo': "something" });
-// Stops a previously started view with the same unique view identifier, and an object to attach additional attribtutes to the view
+// Stops a previously started view with the same unique view identifier, and an object to attach additional attributes to the view
 DdRum.stopView('<view-key>', Date.now(), { 'custom.bar': 42 });
 ```
 
@@ -114,27 +114,27 @@ In addition to manually creating Views (as mentioned above), you can also create
 import { DdRum } from '@datadog/mobile-react-native';
 
 // Track RUM Views manually
-DdRum.startView('<view-key>', 'View Url', Date.now(), {});
+DdRum.startView('<view-key>', 'View Url', {}, Date.now());
 //…
-DdRum.stopView('<view-key>', Date.now(), { 'custom': 42 });
+DdRum.stopView('<view-key>', { 'custom': 42 }, Date.now());
 
 // Track RUM Actions manually
-DdRum.addAction('TAP', 'button name', Date.now(), {});
+DdRum.addAction('TAP', 'button name', {}, Date.now());
 // or in case of continuous action
-DdRum.startAction('TAP', 'button name', Date.now(), {});
+DdRum.startAction('TAP', 'button name', {}, Date.now());
 // to stop action above
-DdRum.stopAction(Date.now(), {});
+DdRum.stopAction({}, Date.now());
 
 // Add custom timings
 DdRum.addTiming('<timing-name>');
 
 // Track RUM Errors manually
-DdRum.addError('<message>', 'source', '<stacktrace>', Date.now(), {});
+DdRum.addError('<message>', 'source', '<stacktrace>', {}, Date.now());
 
 // Track RUM Resource manually
-DdRum.startResource('<res-key>', 'GET', 'http://www.example.com/api/v1/test', Date.now(), {} );
+DdRum.startResource('<res-key>', 'GET', 'http://www.example.com/api/v1/test', {}, Date.now());
 //…
-DdRum.stopResource('<res-key>', 200, 'xhr', Date.now(), {});
+DdRum.stopResource('<res-key>', 200, 'xhr', {}, Date.now());
 ```
 
 ### Logs
@@ -144,7 +144,7 @@ You can send custom log messages from anywhere in your application using the fol
 ```js
 import { DdLogs } from '@datadog/mobile-react-native';
 
-// Send logs (use the debug, info, warn or error methods) with object to attach additional attribtutes to the log
+// Send logs (use the debug, info, warn or error methods) with object to attach additional attributes to the log
 DdLogs.debug("Lorem ipsum dolor sit amet…", { 'custom': 42 });
 DdLogs.info("Lorem ipsum dolor sit amet…", { 'custom': 42 });
 DdLogs.warn("Lorem ipsum dolor sit amet…", { 'custom': 42 });
@@ -158,13 +158,13 @@ You can use spans to trace local computation performance, using the following co
 ```js
 import { DdTrace } from '@datadog/mobile-react-native';
 
-// Start a span with an object to attach additional attribtutes to the span
-const spanId = await DdTrace.startSpan("<operation-name>", Date.now(), { 'custom.x': 42 });
+// Start a span with an object to attach additional attributes to the span
+const spanId = await DdTrace.startSpan("<operation-name>", { 'custom.x': 42 }, Date.now());
 
 // perform some computation...
 
 // Stop the previously started span
-DdTrace.finishSpan(spanId, Date.now(), { 'custom.y': 23 });
+DdTrace.finishSpan(spanId, { 'custom.y': 23 }, Date.now());
 ```
 
 ## Resource timings

--- a/packages/core/src/__tests__/rum/instrumentation/DdEventsInterceptor.test.tsx
+++ b/packages/core/src/__tests__/rum/instrumentation/DdEventsInterceptor.test.tsx
@@ -16,7 +16,6 @@ jest.mock('../../../foundation', () => {
     };
 });
 
-
 // Silence the warning https://github.com/facebook/react-native/issues/11094#issuecomment-263240420
 jest.mock('react-native/Libraries/Animated/src/NativeAnimatedHelper')
 jest.useFakeTimers()

--- a/packages/core/src/__tests__/rum/instrumentation/DdRumErrorTracking.test.tsx
+++ b/packages/core/src/__tests__/rum/instrumentation/DdRumErrorTracking.test.tsx
@@ -14,7 +14,7 @@ jest.mock('../../../foundation', () => {
         DdRum: {
             // eslint-disable-next-line @typescript-eslint/no-empty-function
             addError: jest.fn().mockImplementation(() => {
-                return new Promise((resolve, reject) => {
+                return new Promise<void>((resolve, reject) => {
                     resolve()
                 })
             })
@@ -69,7 +69,7 @@ it('M intercept and send a RUM event W onGlobalError() {empty stack trace}', asy
     expect(DdRum.addError.mock.calls[0][0]).toBe(String(error));
     expect(DdRum.addError.mock.calls[0][1]).toBe("SOURCE");
     expect(DdRum.addError.mock.calls[0][2]).toBe("");
-    const attributes = DdRum.addError.mock.calls[0][4];
+    const attributes = DdRum.addError.mock.calls[0][3];
     expect(attributes["_dd.error.raw"]).toStrictEqual(error);
     expect(attributes["_dd.error.is_crash"]).toStrictEqual(is_fatal);
     expect(baseErrorHandlerCalled).toStrictEqual(true);
@@ -96,7 +96,7 @@ it('M intercept and send a RUM event W onGlobalError() {with source file info}',
     expect(DdRum.addError.mock.calls[0][0]).toBe(String(error));
     expect(DdRum.addError.mock.calls[0][1]).toBe("SOURCE");
     expect(DdRum.addError.mock.calls[0][2]).toBe("at ./path/to/file.js:1038:57");
-    const attributes = DdRum.addError.mock.calls[0][4];
+    const attributes = DdRum.addError.mock.calls[0][3];
     expect(attributes["_dd.error.raw"]).toStrictEqual(error);
     expect(attributes["_dd.error.is_crash"]).toStrictEqual(is_fatal);
     expect(baseErrorHandlerCalled).toStrictEqual(true);
@@ -121,7 +121,7 @@ it('M intercept and send a RUM event W onGlobalError() {with component stack}', 
     expect(DdRum.addError.mock.calls[0][0]).toBe(String(error));
     expect(DdRum.addError.mock.calls[0][1]).toBe("SOURCE");
     expect(DdRum.addError.mock.calls[0][2]).toBe("doSomething() at ./path/to/file.js:67:3,nestedCall() at ./path/to/file.js:1064:9,root() at ./path/to/index.js:10:1");
-    const attributes = DdRum.addError.mock.calls[0][4];
+    const attributes = DdRum.addError.mock.calls[0][3];
     expect(attributes["_dd.error.raw"]).toStrictEqual(error);
     expect(attributes["_dd.error.is_crash"]).toStrictEqual(is_fatal);
     expect(baseErrorHandlerCalled).toStrictEqual(true);
@@ -147,7 +147,7 @@ it('M intercept and send a RUM event W onConsole() {Error with source file info}
     expect(DdRum.addError.mock.calls[0][0]).toBe(message + " " + JSON.stringify(error));
     expect(DdRum.addError.mock.calls[0][1]).toBe("CONSOLE");
     expect(DdRum.addError.mock.calls[0][2]).toBe("at ./path/to/file.js:1038:57");
-    expect(DdRum.addError.mock.calls[0][4]).toStrictEqual({})
+    expect(DdRum.addError.mock.calls[0][3]).toBeUndefined()
     expect(baseConsoleErrorCalled).toStrictEqual(true);
 })
 
@@ -169,7 +169,7 @@ it('M intercept and send a RUM event W onConsole() {Error with component stack}'
     expect(DdRum.addError.mock.calls[0][0]).toBe(message + " " + JSON.stringify(error));
     expect(DdRum.addError.mock.calls[0][1]).toBe("CONSOLE");
     expect(DdRum.addError.mock.calls[0][2]).toBe("doSomething() at ./path/to/file.js:67:3,nestedCall() at ./path/to/file.js:1064:9,root() at ./path/to/index.js:10:1");
-    expect(DdRum.addError.mock.calls[0][4]).toStrictEqual({})
+    expect(DdRum.addError.mock.calls[0][3]).toBeUndefined()
     expect(baseConsoleErrorCalled).toStrictEqual(true);
 })
 
@@ -187,6 +187,6 @@ it('M intercept and send a RUM event W onConsole() {message only}', async () => 
     expect(DdRum.addError.mock.calls[0][0]).toBe(message);
     expect(DdRum.addError.mock.calls[0][1]).toBe("CONSOLE");
     expect(DdRum.addError.mock.calls[0][2]).toBe("");
-    expect(DdRum.addError.mock.calls[0][4]).toStrictEqual({})
+    expect(DdRum.addError.mock.calls[0][3]).toBeUndefined()
     expect(baseConsoleErrorCalled).toStrictEqual(true);
 })

--- a/packages/core/src/__tests__/rum/instrumentation/DdRumResourceTracking.test.tsx
+++ b/packages/core/src/__tests__/rum/instrumentation/DdRumResourceTracking.test.tsx
@@ -15,14 +15,14 @@ jest.mock('../../../foundation', () => {
         DdRum: {
             // eslint-disable-next-line @typescript-eslint/no-empty-function
             startResource: jest.fn().mockImplementation(() => {
-                return new Promise((resolve, reject) => {
+                return new Promise<void>((resolve, reject) => {
                     resolve()
                 })
             }),
 
             // eslint-disable-next-line @typescript-eslint/no-empty-function
             stopResource: jest.fn().mockImplementation(() => {
-                return new Promise((resolve, reject) => {
+                return new Promise<void>((resolve, reject) => {
                     resolve()
                 })
             })
@@ -286,7 +286,7 @@ it('M add the span id as resource attributes W startTracking() + XHR.open() + XH
     await flushPromises();
 
     // THEN
-    const spanId = DdRum.startResource.mock.calls[0][4]["_dd.span_id"];
+    const spanId = DdRum.startResource.mock.calls[0][3]["_dd.span_id"];
     expect(spanId).toBeDefined();
     expect(spanId).toMatch(/[1-9].+/);
 })
@@ -306,7 +306,7 @@ it('M add the trace id as resource attributes W startTracking() + XHR.open() + X
     await flushPromises();
 
     // THEN
-    const traceId = DdRum.startResource.mock.calls[0][4]["_dd.trace_id"];
+    const traceId = DdRum.startResource.mock.calls[0][3]["_dd.trace_id"];
     expect(traceId).toBeDefined();
     expect(traceId).toMatch(/[1-9].+/);
 })
@@ -326,8 +326,8 @@ it('M generate different ids for spanId and traceId for resource attributes', as
     await flushPromises();
 
     // THEN
-    const traceId = DdRum.startResource.mock.calls[0][4]["_dd.trace_id"];
-    const spanId = DdRum.startResource.mock.calls[0][4]["_dd.span_id"];
+    const traceId = DdRum.startResource.mock.calls[0][3]["_dd.trace_id"];
+    const spanId = DdRum.startResource.mock.calls[0][3]["_dd.span_id"];
     expect(traceId !== spanId).toBeTruthy();
 })
 
@@ -351,7 +351,7 @@ describe.each([['android'], ['ios']])('timings test', (platform) => {
         await flushPromises();
 
         // THEN
-        const timings = DdRum.stopResource.mock.calls[0][4]["_dd.resource_timings"];
+        const timings = DdRum.stopResource.mock.calls[0][3]["_dd.resource_timings"];
 
         if (Platform.OS === 'ios') {
             expect(timings['firstByte']['startTime']).toBeGreaterThan(0)
@@ -391,7 +391,7 @@ describe.each([['android'], ['ios']])('timings test', (platform) => {
         await flushPromises();
 
         // THEN
-        const timings = DdRum.stopResource.mock.calls[0][4]["_dd.resource_timings"];
+        const timings = DdRum.stopResource.mock.calls[0][3]["_dd.resource_timings"];
 
         if (Platform.OS === 'ios') {
             expect(timings['firstByte']['startTime']).toBeGreaterThan(0)
@@ -427,7 +427,7 @@ it('M not generate resource timings W startTracking() + XHR.open() + XHR.send() 
     await flushPromises();
 
     // THEN
-    const attributes = DdRum.stopResource.mock.calls[0][4];
+    const attributes = DdRum.stopResource.mock.calls[0][3];
 
     expect(attributes['_dd.resource_timings']).toBeNull()
 })

--- a/packages/core/src/foundation.tsx
+++ b/packages/core/src/foundation.tsx
@@ -7,9 +7,95 @@
 import { NativeModules } from 'react-native';
 import { DdSdkConfiguration, DdSdkType, DdLogsType, DdTraceType, DdRumType } from './types';
 
+class DdLogsWrapper implements DdLogsType {
+
+    private nativeLogs: DdLogsType = NativeModules.DdLogs;
+
+    debug(message: string, context: object = {}): Promise<void> {
+        return this.nativeLogs.debug(message, context);
+    }
+    info(message: string, context: object = {}): Promise<void> {
+        return this.nativeLogs.info(message, context);
+    }
+    warn(message: string, context: object = {}): Promise<void> {
+        return this.nativeLogs.warn(message, context);
+    }
+    error(message: string, context: object = {}): Promise<void> {
+        return this.nativeLogs.error(message, context);
+    }
+
+}
+
+class DdTraceWrapper implements DdTraceType {
+
+    private nativeTrace: DdTraceType = NativeModules.DdTrace;
+
+    startSpan(operation: string, context: object = {}, timestampMs: number = Date.now()): Promise<string> {
+        // TODO swap context and stacktrace in the native call, requires native bridges update
+        // @ts-ignore
+        return this.nativeTrace.startSpan(operation, timestampMs, context);
+    }
+    finishSpan(spanId: string, context: object = {}, timestampMs: number = Date.now()): Promise<void> {
+        // TODO swap context and stacktrace in the native call, requires native bridges update
+        // @ts-ignore
+        return this.nativeTrace.finishSpan(spanId, timestampMs, context);
+    }
+
+}
+
+class DdRumWrapper implements DdRumType {
+
+    private nativeRum: DdRumType = NativeModules.DdRum;
+
+    startView(key: string, name: string, context: object = {}, timestampMs: number = Date.now()): Promise<void> {
+        // TODO swap context and stacktrace in the native call, requires native bridges update
+        // @ts-ignore
+        return this.nativeRum.startView(key, name, timestampMs, context);
+    }
+    stopView(key: string, context: object = {}, timestampMs: number = Date.now()): Promise<void> {
+        // TODO swap context and stacktrace in the native call, requires native bridges update
+        // @ts-ignore
+        return this.nativeRum.stopView(key, timestampMs, context);
+    }
+    startAction(type: string, name: string, context: object = {}, timestampMs: number = Date.now()): Promise<void> {
+        // TODO swap context and stacktrace in the native call, requires native bridges update
+        // @ts-ignore
+        return this.nativeRum.startAction(type, name, timestampMs, context);
+    }
+    stopAction(context: object = {}, timestampMs: number = Date.now()): Promise<void> {
+        // TODO swap context and stacktrace in the native call, requires native bridges update
+        // @ts-ignore
+        return this.nativeRum.stopAction(timestampMs, context);
+    }
+    addAction(type: string, name: string, context: object = {}, timestampMs: number = Date.now()): Promise<void> {
+        // TODO swap context and stacktrace in the native call, requires native bridges update
+        // @ts-ignore
+        return this.nativeRum.addAction(type, name, timestampMs, context);
+    }
+    startResource(key: string, method: string, url: string, context: object = {}, timestampMs: number = Date.now()): Promise<void> {
+        // TODO swap context and stacktrace in the native call, requires native bridges update
+        // @ts-ignore
+        return this.nativeRum.startResource(key, method, url, timestampMs, context);
+    }
+    stopResource(key: string, statusCode: number, kind: string, context: object = {}, timestampMs: number = Date.now()): Promise<void> {
+        // TODO swap context and stacktrace in the native call, requires native bridges update
+        // @ts-ignore
+        return this.nativeRum.stopResource(key, statusCode, kind, timestampMs, context);
+    }
+    addError(message: string, source: string, stacktrace: string, context: object = {}, timestampMs: number = Date.now()): Promise<void> {
+        // TODO swap context and stacktrace in the native call, requires native bridges update
+        // @ts-ignore
+        return this.nativeRum.addError(message, source, stacktrace, timestampMs, context);
+    }
+    addTiming(name: string): Promise<void> {
+        return this.nativeRum.addTiming(name);
+    }
+
+}
+
 const DdSdk: DdSdkType = NativeModules.DdSdk;
-const DdLogs: DdLogsType = NativeModules.DdLogs;
-const DdTrace: DdTraceType = NativeModules.DdTrace;
-const DdRum: DdRumType = NativeModules.DdRum;
+const DdLogs: DdLogsType = new DdLogsWrapper();
+const DdTrace: DdTraceType = new DdTraceWrapper();
+const DdRum: DdRumType = new DdRumWrapper();
 
 export { DdSdkConfiguration, DdSdk, DdLogs, DdTrace, DdRum };

--- a/packages/core/src/rum/instrumentation/DdEventsInterceptor.tsx
+++ b/packages/core/src/rum/instrumentation/DdEventsInterceptor.tsx
@@ -32,7 +32,7 @@ export class DdEventsInterceptor implements EventsInterceptor {
     private handleTargetEvent(targetNode: any | null) {
         if (targetNode) {
             const resolvedTargetName = this.resolveTargetName(targetNode);
-            DdRum.addAction(RumActionType.TAP.valueOf(), resolvedTargetName, Date.now(), {})
+            DdRum.addAction(RumActionType.TAP.valueOf(), resolvedTargetName)
         }
     }
 

--- a/packages/core/src/rum/instrumentation/DdRumErrorTracking.tsx
+++ b/packages/core/src/rum/instrumentation/DdRumErrorTracking.tsx
@@ -52,8 +52,7 @@ export class DdRumErrorTracking {
         DdRum.addError(
             String(error), 
             TYPE_SOURCE, 
-            DdRumErrorTracking.getErrorStackTrace(error), 
-            Date.now(), 
+            DdRumErrorTracking.getErrorStackTrace(error),
             { "_dd.error.is_crash": isFatal, "_dd.error.raw": error }
         ).then(() => {
             DdRumErrorTracking.defaultErrorHandler(error, isFatal);
@@ -81,9 +80,7 @@ export class DdRumErrorTracking {
         DdRum.addError(
             message, 
             TYPE_CONSOLE,
-            stack, 
-            Date.now(), 
-            {}
+            stack
         ).then(() => {
             DdRumErrorTracking.defaultConsoleError.apply(console, params);
         });

--- a/packages/core/src/rum/instrumentation/DdRumResourceTracking.tsx
+++ b/packages/core/src/rum/instrumentation/DdRumResourceTracking.tsx
@@ -197,20 +197,20 @@ export class DdRumResourceTracking {
       key,
       context.method,
       context.url,
-      context.startTime,
       {
         "_dd.span_id": context.spanId,
         "_dd.trace_id": context.traceId
-      }
+      },
+      context.startTime
     ).then(() => {
       DdRum.stopResource(
         key,
         xhrProxy.status,
         "xhr",
-        responseEndTime,
         {
           "_dd.resource_timings": createTimings(context.startTime, context.responseStartTime, responseEndTime),
-        });
+        },
+        responseEndTime);
     })
   }
 

--- a/packages/core/src/types.tsx
+++ b/packages/core/src/types.tsx
@@ -59,28 +59,28 @@ export type DdLogsType = {
    * @param message: The message to send.
    * @param context: The additional context to send.
    */
-  debug(message: string, context: object): Promise<void>;
+  debug(message: string, context?: object): Promise<void>;
 
   /**
    * Send a log with level info.
    * @param message: The message to send.
    * @param context: The additional context to send.
    */
-  info(message: string, context: object): Promise<void>;
+  info(message: string, context?: object): Promise<void>;
 
   /**
    * Send a log with level warn.
    * @param message: The message to send.
    * @param context: The additional context to send.
    */
-  warn(message: string, context: object): Promise<void>;
+  warn(message: string, context?: object): Promise<void>;
 
   /**
    * Send a log with level error.
    * @param message: The message to send.
    * @param context: The additional context to send.
    */
-  error(message: string, context: object): Promise<void>;
+  error(message: string, context?: object): Promise<void>;
 
 };
 
@@ -91,18 +91,18 @@ export type DdTraceType = {
   /**
    * Start a span, and returns a unique identifier for the span.
    * @param operation: The operation name of the span.
-   * @param timestampMs: The timestamp when the operation started (in milliseconds).
    * @param context: The additional context to send.
+   * @param timestampMs: The timestamp when the operation started (in milliseconds).
    */
-  startSpan(operation: string, timestampMs: number, context: object): Promise<string>;
+  startSpan(operation: string, context?: object, timestampMs?: number): Promise<string>;
 
   /**
    * Finish a started span.
    * @param spanId: The unique identifier of the span.
-   * @param timestampMs: The timestamp when the operation stopped (in milliseconds).
    * @param context: The additional context to send.
+   * @param timestampMs: The timestamp when the operation stopped (in milliseconds).
    */
-  finishSpan(spanId: string, timestampMs: number, context: object): Promise<void>;
+  finishSpan(spanId: string, context?: object, timestampMs?: number): Promise<void>;
 
 };
 
@@ -114,73 +114,73 @@ export type DdRumType = {
    * Start tracking a RUM View.
    * @param key: The view unique key identifier.
    * @param name: The view name.
-   * @param timestampMs: The timestamp when the view started (in milliseconds).
    * @param context: The additional context to send.
+   * @param timestampMs: The timestamp when the view started (in milliseconds).
    */
-  startView(key: string, name: string, timestampMs: number, context: object): Promise<void>;
+  startView(key: string, name: string, context?: object, timestampMs?: number): Promise<void>;
 
   /**
    * Stop tracking a RUM View.
    * @param key: The view unique key identifier.
-   * @param timestampMs: The timestamp when the view stopped (in milliseconds).
    * @param context: The additional context to send.
+   * @param timestampMs: The timestamp when the view stopped (in milliseconds).
    */
-  stopView(key: string, timestampMs: number, context: object): Promise<void>;
+  stopView(key: string, context?: object, timestampMs?: number): Promise<void>;
 
   /**
    * Start tracking a RUM Action.
    * @param type: The action type (tap, scroll, swipe, click, custom).
    * @param name: The action name.
-   * @param timestampMs: The timestamp when the action started (in milliseconds).
    * @param context: The additional context to send.
+   * @param timestampMs: The timestamp when the action started (in milliseconds).
    */
-  startAction(type: string, name: string, timestampMs: number, context: object): Promise<void>;
+  startAction(type: string, name: string, context?: object, timestampMs?: number): Promise<void>;
 
   /**
    * Stop tracking the ongoing RUM Action.
-   * @param timestampMs: The timestamp when the action stopped (in milliseconds).
    * @param context: The additional context to send.
+   * @param timestampMs: The timestamp when the action stopped (in milliseconds).
    */
-  stopAction(timestampMs: number, context: object): Promise<void>;
+  stopAction(context?: object, timestampMs?: number): Promise<void>;
 
   /**
    * Add a RUM Action.
    * @param type: The action type (tap, scroll, swipe, click, custom).
    * @param name: The action name.
-   * @param timestampMs: The timestamp when the action occurred (in milliseconds).
    * @param context: The additional context to send.
+   * @param timestampMs: The timestamp when the action occurred (in milliseconds).
    */
-  addAction(type: string, name: string, timestampMs: number, context: object): Promise<void>;
+  addAction(type: string, name: string, context?: object, timestampMs?: number): Promise<void>;
 
   /**
    * Start tracking a RUM Resource.
    * @param key: The resource unique key identifier.
    * @param method: The resource method (GET, POST, …).
    * @param url: The resource url.
-   * @param timestampMs: The timestamp when the resource started (in milliseconds).
    * @param context: The additional context to send.
+   * @param timestampMs: The timestamp when the resource started (in milliseconds).
    */
-  startResource(key: string, method: string, url: string, timestampMs: number, context: object): Promise<void>;
+  startResource(key: string, method: string, url: string, context?: object, timestampMs?: number): Promise<void>;
 
   /**
    * Stop tracking a RUM Resource.
    * @param key: The resource unique key identifier.
    * @param statusCode: The resource status code.
    * @param kind: The resource's kind (xhr, document, image, css, font, …).
-   * @param timestampMs: The timestamp when the resource stopped (in milliseconds).
    * @param context: The additional context to send.
+   * @param timestampMs: The timestamp when the resource stopped (in milliseconds).
    */
-  stopResource(key: string, statusCode: number, kind: string, timestampMs: number, context: object): Promise<void>;
+  stopResource(key: string, statusCode: number, kind: string, context?: object, timestampMs?: number): Promise<void>;
 
   /**
    * Add a RUM Error.
    * @param message: The error message.
    * @param source: The error source (network, source, console, logger, …).
    * @param stacktrace: The error stacktrace.
-   * @param timestampMs: The timestamp when the error occurred (in milliseconds).
    * @param context: The additional context to send.
+   * @param timestampMs: The timestamp when the error occurred (in milliseconds).
    */
-  addError(message: string, source: string, stacktrace: string, timestampMs: number, context: object): Promise<void>;
+  addError(message: string, source: string, stacktrace: string, context?: object, timestampMs?: number): Promise<void>;
 
   /**
    * Adds a specific timing in the active View. The timing duration will be computed as the difference between the time the View was started and the time this function was called.

--- a/packages/react-native-navigation/src/__tests__/rum/instrumentation/DdRumReactNativeNavigationTracking.test.tsx
+++ b/packages/react-native-navigation/src/__tests__/rum/instrumentation/DdRumReactNativeNavigationTracking.test.tsx
@@ -95,7 +95,7 @@ it('M send a RUM ViewEvent W startTracking() componentDidAppear', async () => {
     expect(DdRum.startView.mock.calls.length).toBe(1);
     expect(DdRum.startView.mock.calls[0][0]).toBe(componentId);
     expect(DdRum.startView.mock.calls[0][1]).toBe(componentName);
-    expect(DdRum.startView.mock.calls[0][3]).toStrictEqual({});
+    expect(DdRum.startView.mock.calls[0][2]).toBeUndefined();
 })
 
 
@@ -114,5 +114,5 @@ it('M send a RUM ViewEvent W startTracking() componentDidDisappear', async () =>
     // THEN
     expect(DdRum.stopView.mock.calls.length).toBe(1);
     expect(DdRum.stopView.mock.calls[0][0]).toBe(componentId);
-    expect(DdRum.stopView.mock.calls[0][2]).toStrictEqual({});
+    expect(DdRum.stopView.mock.calls[0][1]).toBeUndefined();
 })

--- a/packages/react-native-navigation/src/rum/instrumentation/DdRumReactNativeNavigationTracking.tsx
+++ b/packages/react-native-navigation/src/rum/instrumentation/DdRumReactNativeNavigationTracking.tsx
@@ -36,10 +36,10 @@ export default class DdRumReactNativeNavigationTracking {
                 Navigation.events().registerComponentListener(
                     {
                         componentDidAppear: (event: ComponentDidAppearEvent) => {
-                            DdRum.startView(componentId, event.componentName, Date.now(), {});
+                            DdRum.startView(componentId, event.componentName);
                         },
                         componentDidDisappear: () => {
-                            DdRum.stopView(componentId, Date.now(), {});
+                            DdRum.stopView(componentId);
                         },
                     },
                     componentId

--- a/packages/react-navigation/src/__tests__/rum/instrumentation/DdRumReactNavigationTracking.test.tsx
+++ b/packages/react-navigation/src/__tests__/rum/instrumentation/DdRumReactNavigationTracking.test.tsx
@@ -70,7 +70,7 @@ it('M send a RUM ViewEvent W startTrackingViews', async () => {
     expect(DdRum.startView.mock.calls.length).toBe(1);
     expect(DdRum.startView.mock.calls[0][0]).toBe(navigationRef1.current?.getCurrentRoute()?.key);
     expect(DdRum.startView.mock.calls[0][1]).toBe(navigationRef1.current?.getCurrentRoute()?.name);
-    expect(DdRum.startView.mock.calls[0][3]).toStrictEqual({});
+    expect(DdRum.startView.mock.calls[0][2]).toBeUndefined();
 })
 
 it('M send a related RUM ViewEvent W switching screens { navigationContainer listener attached }', async () => {
@@ -88,7 +88,7 @@ it('M send a related RUM ViewEvent W switching screens { navigationContainer lis
     expect(DdRum.startView.mock.calls.length).toBe(2);
     expect(DdRum.startView.mock.calls[1][0]).toBe(navigationRef1.current?.getCurrentRoute()?.key);
     expect(DdRum.startView.mock.calls[1][1]).toBe(navigationRef1.current?.getCurrentRoute()?.name);
-    expect(DdRum.startView.mock.calls[1][3]).toStrictEqual({});
+    expect(DdRum.startView.mock.calls[1][2]).toBeUndefined();
 })
 
 it('M only register once W startTrackingViews{ multiple times }', async () => {
@@ -107,7 +107,7 @@ it('M only register once W startTrackingViews{ multiple times }', async () => {
     expect(DdRum.startView.mock.calls.length).toBe(2);
     expect(DdRum.startView.mock.calls[1][0]).toBe(navigationRef1.current?.getCurrentRoute()?.key);
     expect(DdRum.startView.mock.calls[1][1]).toBe(navigationRef1.current?.getCurrentRoute()?.name);
-    expect(DdRum.startView.mock.calls[1][3]).toStrictEqual({});
+    expect(DdRum.startView.mock.calls[1][2]).toBeUndefined();
 })
 
 it('M do nothing W switching screens { navigationContainer listener detached }', async () => {
@@ -156,7 +156,7 @@ it('M send a RUM ViewEvent for each W startTrackingViews { multiple navigation c
     expect(DdRum.startView.mock.calls.length).toBe(2);
     expect(DdRum.startView.mock.calls[1][0]).toBe(navigationRef1.current?.getCurrentRoute()?.key);
     expect(DdRum.startView.mock.calls[1][1]).toBe(navigationRef1.current?.getCurrentRoute()?.name);
-    expect(DdRum.startView.mock.calls[1][3]).toStrictEqual({});
+    expect(DdRum.startView.mock.calls[1][2]).toBeUndefined();
 })
 
 it('M send a RUM ViewEvent for each W startTrackingViews { multiple navigation containers w first is detached }', async () => {
@@ -185,10 +185,10 @@ it('M send a RUM ViewEvent for each W startTrackingViews { multiple navigation c
     expect(DdRum.startView.mock.calls.length).toBe(4);
     expect(DdRum.startView.mock.calls[2][0]).toBe(navigationRef2StartRoute.key);
     expect(DdRum.startView.mock.calls[2][1]).toBe(navigationRef2StartRoute.name);
-    expect(DdRum.startView.mock.calls[2][3]).toStrictEqual({});
+    expect(DdRum.startView.mock.calls[2][2]).toBeUndefined();
     expect(DdRum.startView.mock.calls[3][0]).toBe(navigationRef2.current?.getCurrentRoute()?.key);
     expect(DdRum.startView.mock.calls[3][1]).toBe(navigationRef2.current?.getCurrentRoute()?.name);
-    expect(DdRum.startView.mock.calls[3][3]).toStrictEqual({});
+    expect(DdRum.startView.mock.calls[3][2]).toBeUndefined();
 })
 
 it('M send a RUM ViewEvent for each W switching screens { multiple navigation containers }', async () => {
@@ -205,7 +205,7 @@ it('M send a RUM ViewEvent for each W switching screens { multiple navigation co
     expect(DdRum.startView.mock.calls.length).toBe(1);
     expect(DdRum.startView.mock.calls[0][0]).toBe(navigationRef1.current?.getCurrentRoute()?.key);
     expect(DdRum.startView.mock.calls[0][1]).toBe(navigationRef1.current?.getCurrentRoute()?.name);
-    expect(DdRum.startView.mock.calls[0][3]).toStrictEqual({});
+    expect(DdRum.startView.mock.calls[0][2]).toBeUndefined();
 })
 
 it('M register AppState listener only once', async () => {
@@ -237,7 +237,7 @@ it('M stop active view W app goes into background', async () => {
     // THEN
     expect(DdRum.stopView.mock.calls.length).toBe(1);
     expect(DdRum.stopView.mock.calls[0][0]).toBe(navigationRef1.current?.getCurrentRoute()?.key);
-    expect(DdRum.stopView.mock.calls[0][2]).toStrictEqual({});
+    expect(DdRum.stopView.mock.calls[0][1]).toBeUndefined();
 
 })
 
@@ -257,7 +257,7 @@ it('M start last view W app goes into foreground', async () => {
     expect(DdRum.startView.mock.calls.length).toBe(2);
     expect(DdRum.startView.mock.calls[0][0]).toBe(navigationRef1.current?.getCurrentRoute()?.key);
     expect(DdRum.startView.mock.calls[0][1]).toBe(navigationRef1.current?.getCurrentRoute()?.name);
-    expect(DdRum.startView.mock.calls[0][3]).toStrictEqual({});
+    expect(DdRum.startView.mock.calls[0][2]).toBeUndefined();
 })
 
 it('M not stop view W no navigator attached', async () => {
@@ -291,10 +291,10 @@ it('M send a RUM ViewEvent for each W switching screens { nested navigation cont
     expect(DdRum.startView.mock.calls.length).toBe(2);
     expect(DdRum.startView.mock.calls[0][0]).toBe(initialRoute?.key);
     expect(DdRum.startView.mock.calls[0][1]).toBe(initialRoute?.name);
-    expect(DdRum.startView.mock.calls[0][3]).toStrictEqual({});
+    expect(DdRum.startView.mock.calls[0][2]).toBeUndefined();
     expect(DdRum.startView.mock.calls[1][0]).toBe(navigationRef3.current?.getCurrentRoute()?.key);
     expect(DdRum.startView.mock.calls[1][1]).toBe(navigationRef3.current?.getCurrentRoute()?.name);
-    expect(DdRum.startView.mock.calls[1][3]).toStrictEqual({});
+    expect(DdRum.startView.mock.calls[1][2]).toBeUndefined();
 })
 
 

--- a/packages/react-navigation/src/rum/instrumentation/DdRumReactNavigationTracking.tsx
+++ b/packages/react-navigation/src/rum/instrumentation/DdRumReactNavigationTracking.tsx
@@ -59,7 +59,7 @@ export default class DdRumReactNavigationTracking {
         const key = route?.key;
         const screenName = route?.name;
         if (key != null && screenName != null) {
-            DdRum.startView(key, screenName, Date.now(), {});
+            DdRum.startView(key, screenName);
         }
     }
 
@@ -98,11 +98,11 @@ export default class DdRumReactNavigationTracking {
 
                 if (currentViewKey != null && currentViewName != null) {
                     if (appStateStatus === 'background') {
-                        DdRum.stopView(currentViewKey, Date.now(), {});
+                        DdRum.stopView(currentViewKey);
                     } else if (appStateStatus === 'active') {
                         // case when app goes into foreground, in that case navigation listener
                         // won't be called
-                        DdRum.startView(currentViewKey, currentViewName, Date.now(), {});
+                        DdRum.startView(currentViewKey, currentViewName);
                     }
                 }
             };


### PR DESCRIPTION
Outcome of the change done here https://github.com/DataDog/dd-mobile-bridge/pull/32

Introduces optional arguments, does the necessary update of the tests. Support of optional arguments means that if we had the following method before:

```
startView(key: string, name: string, context: object, timestampMs: number);
```
it could be called only in a one way, like `startView("foo", "bar", {}, Date.now())`, creating some complexities for the customer, because most of the time `context` and `timestampMs` are the same: `{}` and `Date.now()` respectively.

Now, with optional arguments (considering we've made `context` and `timestampMs` optional) support, it is possible to have any of the following:

```
startView("foo", "bar")
startView("foo", "bar", {})
startView("foo", "bar", {}, Date.now())
```

Unfortunately there is no named parameters neither in JS nor in TS, so all parameters are just positional, we cannot mix their order or skip something in the middle.

### Additional Notes

Since this change does the swap of `context` and `timestamp`, change in the arguments position on the native side is required as well, but that would require to publish new versions of the bridges. So for now we swap these arguments back before calling native layer and suppress TS error.