### PR TITLE
RUMM-1291 Let customers rename views

### DIFF
--- a/example/src/App.tsx
+++ b/example/src/App.tsx
@@ -6,11 +6,11 @@ import AboutScreen from './screens/AboutScreen';
 import style from './screens/styles';
 import { navigationRef } from './NavigationRoot';
 import { DdRumReactNavigationTracking, ViewNamePredicate } from '@datadog/mobile-react-navigation';
+import { Route } from "@react-navigation/native";
 
 const Tab = createBottomTabNavigator();
 
-const viewPredicate: ViewNamePredicate = function customViewNamePredicate(trackedView: any, trackedName: string) {
-  console.log(trackedView);
+const viewPredicate: ViewNamePredicate = function customViewNamePredicate(route: Route<string, any | undefined>, trackedName: string) {
   return "Custom RN " + trackedName;
 }
 

--- a/example/src/App.tsx
+++ b/example/src/App.tsx
@@ -5,14 +5,19 @@ import MainScreen from './screens/MainScreen';
 import AboutScreen from './screens/AboutScreen';
 import style from './screens/styles';
 import { navigationRef } from './NavigationRoot';
-import { DdRumReactNavigationTracking } from '@datadog/mobile-react-navigation';
+import { DdRumReactNavigationTracking, ViewNamePredicate } from '@datadog/mobile-react-navigation';
 
 const Tab = createBottomTabNavigator();
+
+const viewPredicate: ViewNamePredicate = function customViewNamePredicate(trackedView: any, trackedName: string) {
+  console.log(trackedView);
+  return "Custom RN " + trackedName;
+}
 
 export default function App() {
   return (
     <NavigationContainer ref={navigationRef} onReady={() => {
-      DdRumReactNavigationTracking.startTrackingViews(navigationRef.current)
+      DdRumReactNavigationTracking.startTrackingViews(navigationRef.current, viewPredicate)
     }}>
       <Tab.Navigator tabBarOptions={{
         labelStyle: style.tabLabelStyle,

--- a/example/src/WixApp.tsx
+++ b/example/src/WixApp.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import { View, Text, Button } from 'react-native';
-import { Navigation } from 'react-native-navigation';
+import { ComponentDidAppearEvent, Navigation } from 'react-native-navigation';
 import MainScreen from './screens/MainScreen';
 import AboutScreen from './screens/AboutScreen';
 import { DdRumReactNativeNavigationTracking, ViewNamePredicate }  from '@datadog/mobile-react-native-navigation';
@@ -8,8 +8,7 @@ import { DdRumReactNativeNavigationTracking, ViewNamePredicate }  from '@datadog
 
 import styles from './screens/styles';
 
-const viewPredicate: ViewNamePredicate = function customViewNamePredicate(trackedView: any, trackedName: string) {
-  console.log(trackedView);
+const viewPredicate: ViewNamePredicate = function customViewNamePredicate(_event: ComponentDidAppearEvent, trackedName: string) {
   return "Custom RNN " + trackedName;
 }
 

--- a/example/src/WixApp.tsx
+++ b/example/src/WixApp.tsx
@@ -3,13 +3,19 @@ import { View, Text, Button } from 'react-native';
 import { Navigation } from 'react-native-navigation';
 import MainScreen from './screens/MainScreen';
 import AboutScreen from './screens/AboutScreen';
-import { DdRumReactNativeNavigationTracking }  from '@datadog/mobile-react-native-navigation';
+import { DdRumReactNativeNavigationTracking, ViewNamePredicate }  from '@datadog/mobile-react-native-navigation';
 
 
 import styles from './screens/styles';
 
+const viewPredicate: ViewNamePredicate = function customViewNamePredicate(trackedView: any, trackedName: string) {
+  console.log(trackedView);
+  return "Custom RNN " + trackedName;
+}
+
+
 function startReactNativeNavigation() {
-    DdRumReactNativeNavigationTracking.startTracking();
+    DdRumReactNativeNavigationTracking.startTracking(viewPredicate);
     registerScreens();
     Navigation.events().registerAppLaunchedListener(async () => {
       Navigation.setRoot({

--- a/packages/react-native-navigation/README.md
+++ b/packages/react-native-navigation/README.md
@@ -20,12 +20,16 @@ yarn add @datadog/mobile-react-native-navigation
 
 ### Track view navigation
 
-In order to start tracking your navigation events, simply call the add the following lines before setting up your navigation:
+In order to start tracking your navigation events, simply call the add the following lines before setting up your navigation. You can use the optional `ViewNamePredicate` parameter to replace the automatically detected View name with something more relevant to your use case.
 
 ```js
-import { DdRumReactNativeNavigationTracking }  from '@datadog/mobile-react-native-navigation';
+import { DdRumReactNativeNavigationTracking, ViewNamePredicate }  from '@datadog/mobile-react-native-navigation';
 
-DdRumReactNativeNavigationTracking.startTracking();
+const viewNamePredicate: ViewNamePredicate = function customViewNamePredicate(trackedView: any, trackedName: string) {
+  return "My custom View Name"
+}
+
+DdRumReactNativeNavigationTracking.startTracking(viewNamePredicate);
 ```
 
 [1]: https://github.com/wix/react-native-navigation

--- a/packages/react-native-navigation/README.md
+++ b/packages/react-native-navigation/README.md
@@ -20,12 +20,13 @@ yarn add @datadog/mobile-react-native-navigation
 
 ### Track view navigation
 
-In order to start tracking your navigation events, simply call the add the following lines before setting up your navigation. You can use the optional `ViewNamePredicate` parameter to replace the automatically detected View name with something more relevant to your use case.
+In order to start tracking your navigation events, simply call the add the following lines before setting up your navigation. You can use the optional `ViewNamePredicate` callback to replace the automatically detected View name with something more relevant to your use case, based on the [`ComponentDidAppearEvent`][3].
 
 ```js
 import { DdRumReactNativeNavigationTracking, ViewNamePredicate }  from '@datadog/mobile-react-native-navigation';
+import { ComponentDidAppearEvent } from 'react-native-navigation';
 
-const viewNamePredicate: ViewNamePredicate = function customViewNamePredicate(trackedView: any, trackedName: string) {
+const viewNamePredicate: ViewNamePredicate = function customViewNamePredicate(event: ComponentDidAppearEvent, trackedName: string) {
   return "My custom View Name"
 }
 
@@ -34,3 +35,4 @@ DdRumReactNativeNavigationTracking.startTracking(viewNamePredicate);
 
 [1]: https://github.com/wix/react-native-navigation
 [2]: https://github.com/DataDog/dd-sdk-reactnative/tree/main/packages/core
+[3]: https://wix.github.io/react-native-navigation/api/events/#componentdidappear

--- a/packages/react-native-navigation/src/__tests__/rum/instrumentation/DdRumReactNativeNavigationTracking.test.tsx
+++ b/packages/react-native-navigation/src/__tests__/rum/instrumentation/DdRumReactNativeNavigationTracking.test.tsx
@@ -6,6 +6,7 @@
 
 import React from 'react';
 import { DdRum } from '@datadog/mobile-react-native';
+import { ComponentDidAppearEvent } from 'react-native-navigation';
 import { DdRumReactNativeNavigationTracking, ViewNamePredicate } from '../../../rum/instrumentation/DdRumReactNativeNavigationTracking';
 
 jest.mock('@datadog/mobile-react-native', () => {
@@ -121,11 +122,10 @@ it('M send a RUM ViewEvent W startTracking() componentDidAppear', async () => {
 
 
 it('M send a RUM ViewEvent W startTracking() componentDidAppear { custom viewPredicate }', async () => {
-    console.log("!!!!!!!")
     // GIVEN
     let componentId = "component42"
     const customViewName = "custom_view_name"
-    const predicate: ViewNamePredicate = function customViewNamePredicate(_trackedView: any, _trackedName: string)  { 
+    const predicate: ViewNamePredicate = function (_event: ComponentDidAppearEvent, _trackedName: string)  { 
         return customViewName 
     };
     DdRumReactNativeNavigationTracking.startTracking(predicate);

--- a/packages/react-native-navigation/src/__tests__/rum/instrumentation/DdRumReactNativeNavigationTracking.test.tsx
+++ b/packages/react-native-navigation/src/__tests__/rum/instrumentation/DdRumReactNativeNavigationTracking.test.tsx
@@ -6,7 +6,7 @@
 
 import React from 'react';
 import { DdRum } from '@datadog/mobile-react-native';
-import DdRumReactNativeNavigationTracking from '../../../rum/instrumentation/DdRumReactNativeNavigationTracking';
+import { DdRumReactNativeNavigationTracking, ViewNamePredicate } from '../../../rum/instrumentation/DdRumReactNativeNavigationTracking';
 
 jest.mock('@datadog/mobile-react-native', () => {
     return {
@@ -119,6 +119,29 @@ it('M send a RUM ViewEvent W startTracking() componentDidAppear', async () => {
 })
 
 
+
+it('M send a RUM ViewEvent W startTracking() componentDidAppear { custom viewPredicate }', async () => {
+    console.log("!!!!!!!")
+    // GIVEN
+    let componentId = "component42"
+    const customViewName = "custom_view_name"
+    const predicate: ViewNamePredicate = function customViewNamePredicate(_trackedView: any, _trackedName: string)  { 
+        return customViewName 
+    };
+    DdRumReactNativeNavigationTracking.startTracking(predicate);
+
+    // WHEN
+    const testInstance = React.createElement('View', { 'componentId': componentId });
+    const listener = mockRegisterComponentListener.mock.calls[0][0];
+    const componentName = "some-name";
+    listener.componentDidAppear({ componentName: componentName });
+
+    // THEN
+    expect(DdRum.startView.mock.calls.length).toBe(1);
+    expect(DdRum.startView.mock.calls[0][0]).toBe(componentId);
+    expect(DdRum.startView.mock.calls[0][1]).toBe(customViewName);
+    expect(DdRum.startView.mock.calls[0][2]).toBeUndefined();
+})
 
 it('M send a RUM ViewEvent W startTracking() componentDidDisappear', async () => {
 

--- a/packages/react-native-navigation/src/index.tsx
+++ b/packages/react-native-navigation/src/index.tsx
@@ -4,6 +4,6 @@
  * Copyright 2016-Present Datadog, Inc.
  */
 
-import DdRumReactNativeNavigationTracking from './rum/instrumentation/DdRumReactNativeNavigationTracking';
+import { DdRumReactNativeNavigationTracking, ViewNamePredicate } from './rum/instrumentation/DdRumReactNativeNavigationTracking';
 
-export { DdRumReactNativeNavigationTracking };
+export { DdRumReactNativeNavigationTracking, ViewNamePredicate };

--- a/packages/react-native-navigation/src/rum/instrumentation/DdRumReactNativeNavigationTracking.tsx
+++ b/packages/react-native-navigation/src/rum/instrumentation/DdRumReactNativeNavigationTracking.tsx
@@ -8,7 +8,7 @@ import React from 'react'
 import { ComponentDidAppearEvent, Navigation } from 'react-native-navigation';
 import { DdRum } from '@datadog/mobile-react-native';
 
-export type ViewNamePredicate = (event: ComponentDidAppearEvent, trackedName: string) => string | null
+export type ViewNamePredicate = (event: ComponentDidAppearEvent, trackedName: string) => string
 
 /**
 * Provides RUM integration for the [React Native Navigation](https://wix.github.io/react-native-navigation) API.

--- a/packages/react-native-navigation/src/rum/instrumentation/DdRumReactNativeNavigationTracking.tsx
+++ b/packages/react-native-navigation/src/rum/instrumentation/DdRumReactNativeNavigationTracking.tsx
@@ -8,10 +8,7 @@ import React from 'react'
 import { ComponentDidAppearEvent, Navigation } from 'react-native-navigation';
 import { DdRum } from '@datadog/mobile-react-native';
 
-
-
-
-export type ViewNamePredicate = (trackedView: any, trackedName: string) => string | null
+export type ViewNamePredicate = (event: ComponentDidAppearEvent, trackedName: string) => string | null
 
 /**
 * Provides RUM integration for the [React Native Navigation](https://wix.github.io/react-native-navigation) API.
@@ -27,7 +24,7 @@ export class DdRumReactNativeNavigationTracking {
     /**
      * Starts tracking the Navigation and sends a RUM View event every time a root View component appear/disappear.
      */
-    static startTracking(viewNamePredicate: ViewNamePredicate = function defaultViewNamePredicate(_trackedView: any, trackedName: string) { return trackedName; }): void {
+    static startTracking(viewNamePredicate: ViewNamePredicate = function (_event: ComponentDidAppearEvent, trackedName: string) { return trackedName; }): void {
         // extra safety to avoid wrapping more than 1 time this function
         if (DdRumReactNativeNavigationTracking.isTracking) {
             return
@@ -73,5 +70,6 @@ export class DdRumReactNativeNavigationTracking {
         }
         DdRumReactNativeNavigationTracking.trackedComponentIds.splice(0, DdRumReactNativeNavigationTracking.trackedComponentIds.length)
         DdRumReactNativeNavigationTracking.isTracking = false
+        DdRumReactNativeNavigationTracking.viewNamePredicate = function (_event: ComponentDidAppearEvent, trackedName: string) { return trackedName; }
     }
 }

--- a/packages/react-navigation/README.md
+++ b/packages/react-navigation/README.md
@@ -25,8 +25,9 @@ To track changes in navigation as RUM Views, set the `onready` callback of your 
 ```js
 import * as React from 'react';
 import { DdRumReactNavigationTracking, ViewNamePredicate } from '@datadog/mobile-react-navigation';
+import { Route } from "@react-navigation/native";
 
-const viewNamePredicate: ViewNamePredicate = function customViewNamePredicate(trackedView: any, trackedName: string) {
+const viewNamePredicate: ViewNamePredicate = function customViewNamePredicate(route: Route<string, any | undefined>, trackedName: string) {
   return "My custom View Name"
 }
 

--- a/packages/react-navigation/README.md
+++ b/packages/react-navigation/README.md
@@ -20,18 +20,22 @@ yarn add @datadog/mobile-react-navigation
 
 ### Track view navigation
 
-To track changes in navigation as RUM Views, set the `onready` callback of your `NavigationContainer` component:
+To track changes in navigation as RUM Views, set the `onready` callback of your `NavigationContainer` component as follow. You can use the optional `ViewNamePredicate` parameter to replace the automatically detected View name with something more relevant to your use case.
 
 ```js
 import * as React from 'react';
-import { DdRumReactNavigationTracking } from '@datadog/mobile-react-navigation';
+import { DdRumReactNavigationTracking, ViewNamePredicate } from '@datadog/mobile-react-navigation';
+
+const viewNamePredicate: ViewNamePredicate = function customViewNamePredicate(trackedView: any, trackedName: string) {
+  return "My custom View Name"
+}
 
 function App() {
   const navigationRef = React.useRef(null);
   return (
     <View>
       <NavigationContainer ref={navigationRef} onReady={() => {
-        DdRumReactNavigationTracking.startTrackingViews(navigationRef.current)
+        DdRumReactNavigationTracking.startTrackingViews(navigationRef.current, viewNamePredicate)
       }}>
         // …
       </NavigationContainer>

--- a/packages/react-navigation/src/__tests__/rum/instrumentation/DdRumReactNavigationTracking.test.tsx
+++ b/packages/react-navigation/src/__tests__/rum/instrumentation/DdRumReactNavigationTracking.test.tsx
@@ -6,7 +6,7 @@
 
 import React from 'react';
 import { View, Text, Button, AppState } from 'react-native';
-import { NavigationContainer, NavigationContainerRef } from '@react-navigation/native';
+import { NavigationContainer, NavigationContainerRef, Route } from '@react-navigation/native';
 import { DdRum } from '@datadog/mobile-react-native';
 import { DdRumReactNavigationTracking, ViewNamePredicate} from '../../../rum/instrumentation/DdRumReactNavigationTracking';
 import { render, fireEvent } from '@testing-library/react-native';
@@ -96,7 +96,7 @@ it('M send a related RUM ViewEvent W switching screens { viewPredicate provided 
     const { getByText } = render(<FakeNavigator1 />);
     const goToAboutButton = getByText('Go to About');
     const customViewName = "custom_view_name"
-    const predicate: ViewNamePredicate = function customViewNamePredicate(_trackedView: any, _trackedName: string)  { 
+    const predicate: ViewNamePredicate = function (_route: Route<string, any | undefined>, _trackedName: string)  { 
         return customViewName 
     };
     DdRumReactNavigationTracking.startTrackingViews(navigationRef1.current, predicate);

--- a/packages/react-navigation/src/index.tsx
+++ b/packages/react-navigation/src/index.tsx
@@ -4,6 +4,6 @@
  * Copyright 2016-Present Datadog, Inc.
  */
 
-import DdRumReactNavigationTracking from './rum/instrumentation/DdRumReactNavigationTracking';
+import { DdRumReactNavigationTracking, ViewNamePredicate } from './rum/instrumentation/DdRumReactNavigationTracking';
 
-export { DdRumReactNavigationTracking };
+export { DdRumReactNavigationTracking, ViewNamePredicate };

--- a/packages/react-navigation/src/rum/instrumentation/DdRumReactNavigationTracking.tsx
+++ b/packages/react-navigation/src/rum/instrumentation/DdRumReactNavigationTracking.tsx
@@ -18,7 +18,7 @@ declare type NavigationListener = (event: EventArg<string, boolean, any>) => voi
 //     'extension' [iOS] - The app is running as an app extension
 declare type AppStateListener = (appStateStatus: AppStateStatus) => void | null
 
-export type ViewNamePredicate = (route: Route<string, any | undefined>, trackedName: string) => string | null
+export type ViewNamePredicate = (route: Route<string, any | undefined>, trackedName: string) => string
 
 /**
  * Provides RUM integration for the [ReactNavigation](https://reactnavigation.org/) API.

--- a/packages/react-navigation/src/rum/instrumentation/DdRumReactNavigationTracking.tsx
+++ b/packages/react-navigation/src/rum/instrumentation/DdRumReactNavigationTracking.tsx
@@ -18,7 +18,7 @@ declare type NavigationListener = (event: EventArg<string, boolean, any>) => voi
 //     'extension' [iOS] - The app is running as an app extension
 declare type AppStateListener = (appStateStatus: AppStateStatus) => void | null
 
-export type ViewNamePredicate = (trackedView: any, trackedName: string) => string | null
+export type ViewNamePredicate = (route: Route<string, any | undefined>, trackedName: string) => string | null
 
 /**
  * Provides RUM integration for the [ReactNavigation](https://reactnavigation.org/) API.
@@ -39,7 +39,7 @@ export class DdRumReactNavigationTracking {
      */
     static startTrackingViews(
             navigationRef: NavigationContainerRef | null,
-            viewNamePredicate: ViewNamePredicate = function defaultViewNamePredicate(_trackedView: any, trackedName: string) { return trackedName; }
+            viewNamePredicate: ViewNamePredicate = function (_route: Route<string, any | undefined>, trackedName: string) { return trackedName; }
         ): void {
 
         if (navigationRef == null) {
@@ -69,6 +69,7 @@ export class DdRumReactNavigationTracking {
         if (navigationRef != null) {
             navigationRef.removeListener("state", DdRumReactNavigationTracking.navigationStateChangeListener);
             DdRumReactNavigationTracking.registeredContainer = null;
+            DdRumReactNavigationTracking.viewNamePredicate = function (_route: Route<string, any | undefined>, trackedName: string) { return trackedName; }
         }
     }
 

--- a/packages/react-navigation/src/rum/instrumentation/DdRumReactNavigationTracking.tsx
+++ b/packages/react-navigation/src/rum/instrumentation/DdRumReactNavigationTracking.tsx
@@ -10,12 +10,20 @@ import { AppState, AppStateStatus } from 'react-native';
 
 declare type NavigationListener = (event: EventArg<string, boolean, any>) => void | null
 
+// AppStateStatus can have values: 
+//     'active' - The app is running in the foreground
+//     'background' - The app is running in the background. The user is either in another app or on the home screen
+//     'inactive' [iOS] - This is a transition state that currently never happens for typical React Native apps.
+//     'unknown' [iOS] - Initial value until the current app state is determined
+//     'extension' [iOS] - The app is running as an app extension
 declare type AppStateListener = (appStateStatus: AppStateStatus) => void | null
+
+export type ViewNamePredicate = (trackedView: any, trackedName: string) => string | null
 
 /**
  * Provides RUM integration for the [ReactNavigation](https://reactnavigation.org/) API.
  */
-export default class DdRumReactNavigationTracking {
+export class DdRumReactNavigationTracking {
 
     private static registeredContainer: NavigationContainerRef | null;
     
@@ -23,23 +31,32 @@ export default class DdRumReactNavigationTracking {
 
     private static appStateListener: AppStateListener;
 
+    private static viewNamePredicate: ViewNamePredicate;
+
     /**
      * Starts tracking the NavigationContainer and sends a RUM View event every time the navigation route changed.
      * @param navigationRef the reference to the real NavigationContainer.
      */
-    static startTrackingViews(navigationRef: NavigationContainerRef | null): void {
+    static startTrackingViews(
+            navigationRef: NavigationContainerRef | null,
+            viewNamePredicate: ViewNamePredicate = function defaultViewNamePredicate(_trackedView: any, trackedName: string) { return trackedName; }
+        ): void {
+
         if (navigationRef == null) {
+            console.log ("Cannot track views with a null navigationRef");
             return;
         }
 
         if (DdRumReactNavigationTracking.registeredContainer != null && this.registeredContainer !== navigationRef) {
             console.error('Cannot track new navigation container while another one is still tracked');
         } else if (DdRumReactNavigationTracking.registeredContainer == null) {
+            DdRumReactNavigationTracking.viewNamePredicate = viewNamePredicate;
             const listener = DdRumReactNavigationTracking.resolveNavigationStateChangeListener();
             DdRumReactNavigationTracking.handleRouteNavigation(navigationRef.getCurrentRoute());
             navigationRef.addListener("state", listener);
             DdRumReactNavigationTracking.registeredContainer = navigationRef;
         }
+
 
         DdRumReactNavigationTracking.registerAppStateListenerIfNeeded();
     }
@@ -55,11 +72,27 @@ export default class DdRumReactNavigationTracking {
         }
     }
 
-    private static handleRouteNavigation(route: Route<string, any | undefined> | undefined) {
-        const key = route?.key;
-        const screenName = route?.name;
+    private static handleRouteNavigation(
+        route: Route<string, any | undefined> | undefined, 
+        appStateStatus: AppStateStatus | undefined = undefined
+        ) {
+        if (route == undefined || route == null) {
+            // RUMM-1400 in some cases the route seem to be undefined
+            return
+        }
+        const key = route.key;
+
+        const predicate = DdRumReactNavigationTracking.viewNamePredicate;
+        const screenName = predicate(route, route.name) ?? route.name;
+
         if (key != null && screenName != null) {
-            DdRum.startView(key, screenName);
+            if (appStateStatus === 'background') {
+                DdRum.stopView(key);
+            } else if (appStateStatus === 'active' || appStateStatus == undefined) {
+                // case when app goes into foreground, 
+                // in that case navigation listener won't be called
+                DdRum.startView(key, screenName);
+            }
         }
     }
 
@@ -93,18 +126,11 @@ export default class DdRumReactNavigationTracking {
             DdRumReactNavigationTracking.appStateListener = (appStateStatus: AppStateStatus) => {
 
                 const currentRoute = DdRumReactNavigationTracking.registeredContainer?.getCurrentRoute();
-                const currentViewKey = currentRoute?.key;
-                const currentViewName = currentRoute?.name;
-
-                if (currentViewKey != null && currentViewName != null) {
-                    if (appStateStatus === 'background') {
-                        DdRum.stopView(currentViewKey);
-                    } else if (appStateStatus === 'active') {
-                        // case when app goes into foreground, in that case navigation listener
-                        // won't be called
-                        DdRum.startView(currentViewKey, currentViewName);
-                    }
+                if (currentRoute == undefined) {
+                    return;
                 }
+
+                DdRumReactNavigationTracking.handleRouteNavigation(currentRoute, appStateStatus);
             };
 
             // AppState is singleton, so we should add a listener only once in the app lifetime


### PR DESCRIPTION
### What does this PR do?

Add a `ViewPredicate` option for the auto instrumented view tracking packages to let the customer replace the automatically found `view.name` by a custom one.
