### PR TITLE
RUMM-2080 Use performance.now when available to compute events' timing

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -31,6 +31,7 @@ local.properties
 
 # VS Code
 .vscode
+*.save
 
 # node.js
 #

--- a/packages/core/src/TimeProvider.tsx
+++ b/packages/core/src/TimeProvider.tsx
@@ -1,0 +1,64 @@
+/*
+ * Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
+ * This product includes software developed at Datadog (https://www.datadoghq.com/).
+ * Copyright 2016-Present Datadog, Inc.
+ */
+
+/**
+ * A Timestamp structure holding the
+ */
+export type Timestamp = {
+    // Result of Date API. Unix timestamp in ms.
+    unix: number,
+    // Result of performance.now API. Timestamp in ms (with microsecond precision)
+    // since JS context start.
+    react_native: number | null
+}
+
+/**
+ * Simple class providing timestamps in milliseconds.
+ * If available, it will use the `performance.now()` method, and will fallback on `Date.now()` otherwise.
+ */
+export class TimeProvider {
+
+    // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+    // @ts-ignore
+    private canUsePerformanceNow = global.performance && typeof performance.now === 'function';
+
+    /** Keeps an average offset between the unix time and the provided timestamp. */
+    private baseOffset: number
+
+    constructor() {
+        const timestamp = this.getTimestamp();
+        if (timestamp.react_native == null) {
+            this.baseOffset = 0;
+        } else {
+            this.baseOffset = timestamp.unix - timestamp.react_native;
+        }
+    }
+
+    getTimestamp(): Timestamp {
+        return {
+            unix: Date.now(),
+            react_native: this.performanceNow()
+        }
+    }
+
+    now(): number {
+        const timestamp = this.getTimestamp();
+        if (timestamp.react_native == null) {
+            return timestamp.unix
+        } else {
+            return this.baseOffset + timestamp.react_native;
+        }
+    }
+
+    private performanceNow(): number | null {
+        if (this.canUsePerformanceNow) {
+            // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+            // @ts-ignore
+            return performance.now();
+        }
+        return null;
+    }
+}

--- a/packages/core/src/Timer.ts
+++ b/packages/core/src/Timer.ts
@@ -1,10 +1,11 @@
-type Timestamp = {
-    // Result of Date API. Unix timestamp in ms.
-    unix: number,
-    // Result of performance.now API. Timestamp in ms (with microsecond precision)
-    // since JS context start.
-    react_native: number | null
-}
+/*
+ * Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
+ * This product includes software developed at Datadog (https://www.datadoghq.com/).
+ * Copyright 2016-Present Datadog, Inc.
+ */
+
+import {TimeProvider, Timestamp} from "./TimeProvider";
+
 
 const START_LABEL = "__start"
 const STOP_LABEL = "__stop"
@@ -15,7 +16,12 @@ const STOP_LABEL = "__stop"
  */
 export default class Timer {
 
+    private timeProvider: TimeProvider;
     private times: Record<string, Timestamp> = {};
+
+    constructor(timeProvider: TimeProvider = new TimeProvider()) {
+        this.timeProvider = timeProvider;
+    }
 
     get startTime(): number {
         return this.times[START_LABEL].unix
@@ -34,10 +40,7 @@ export default class Timer {
     }
 
     recordTick(label: string): void {
-        this.times[label] = {
-            unix: Date.now(),
-            react_native: this.performanceNow()
-        }
+        this.times[label] = this.timeProvider.getTimestamp();
     }
 
     hasTickFor(label: string): boolean {
@@ -69,22 +72,6 @@ export default class Timer {
             return end.react_native - start.react_native;
         }
         return end.unix - start.unix;
-    }
-
-
-    private performanceNow(): number | null {
-        if (this.canUsePerformanceNow()) {
-            // eslint-disable-next-line @typescript-eslint/ban-ts-comment
-            // @ts-ignore
-            return performance.now();
-        }
-        return null;
-    }
-
-    private canUsePerformanceNow(): boolean {
-        // eslint-disable-next-line @typescript-eslint/ban-ts-comment
-        // @ts-ignore
-        return global.performance && typeof performance.now === 'function';
     }
 
     private checkLabelExists(label: string) {

--- a/packages/core/src/__tests__/TimeProvider.test.tsx
+++ b/packages/core/src/__tests__/TimeProvider.test.tsx
@@ -1,0 +1,75 @@
+/*
+ * Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
+ * This product includes software developed at Datadog (https://www.datadoghq.com/).
+ * Copyright 2016-Present Datadog, Inc.
+ */
+
+import { TimeProvider } from '../TimeProvider'
+
+
+function mockDateNow(value: number){
+    Date.now = (): number => {
+        return value;
+    }
+}
+
+function mockPerformanceNow(value: number = 0){
+    // @ts-ignore
+    global.performance = {
+        now: (): number => {
+            return value;
+        }
+    }
+}
+
+function randomInt(): number {
+    return Math.floor(Math.random() * 65536) + 512
+}
+
+let dateTime: number
+let perfTime: number
+
+beforeEach(() => {
+    dateTime = randomInt();
+    perfTime = randomInt();
+    mockDateNow(dateTime);
+    mockPerformanceNow(perfTime);
+})
+
+it('M use performance W available', () => {
+    // GIVEN
+    const timeProvider = new TimeProvider();
+
+    // WHEN
+    const result = timeProvider.getTimestamp();
+
+    // THEN
+    expect(result.unix).toBe(dateTime);
+    expect(result.react_native).toBe(perfTime);
+})
+
+it('M ignore performance W global.performance unavailable', () => {
+    // GIVEN
+    delete global.performance;
+    const timeProvider = new TimeProvider();
+
+    // WHEN
+    const result = timeProvider.getTimestamp();
+
+    // THEN
+    expect(result.unix).toBe(dateTime);
+    expect(result.react_native).toBe(null);
+})
+
+it('M ignore performance W unavailable', () => {
+    // GIVEN
+    delete global.performance.now;
+    const timeProvider = new TimeProvider();
+
+    // WHEN
+    const result = timeProvider.getTimestamp();
+
+    // THEN
+    expect(result.unix).toBe(dateTime);
+    expect(result.react_native).toBe(null);
+})

--- a/packages/core/src/foundation.tsx
+++ b/packages/core/src/foundation.tsx
@@ -8,6 +8,9 @@ import { NativeModules } from 'react-native';
 import { DdSdkConfiguration, DdSdkType, DdLogsType, DdTraceType, DdRumType } from './types';
 import {InternalLog} from "./InternalLog"
 import {SdkVerbosity} from "./SdkVerbosity";
+import {TimeProvider} from "./TimeProvider";
+
+const timeProvider = new TimeProvider();
 
 class DdLogsWrapper implements DdLogsType {
 
@@ -39,13 +42,13 @@ class DdTraceWrapper implements DdTraceType {
 
     private nativeTrace: DdTraceType = NativeModules.DdTrace;
 
-    startSpan(operation: string, context: object = {}, timestampMs: number = Date.now()): Promise<string> {
+    startSpan(operation: string, context: object = {}, timestampMs: number = timeProvider.now()): Promise<string> {
         let spanId = this.nativeTrace.startSpan(operation, context, timestampMs);
         InternalLog.log("Starting span “" +  operation + "” #" + spanId, SdkVerbosity.DEBUG);
         return spanId
     }
 
-    finishSpan(spanId: string, context: object = {}, timestampMs: number = Date.now()): Promise<void> {
+    finishSpan(spanId: string, context: object = {}, timestampMs: number = timeProvider.now()): Promise<void> {
         InternalLog.log("Finishing span #" +  spanId, SdkVerbosity.DEBUG);
         return this.nativeTrace.finishSpan(spanId, context, timestampMs);
     }
@@ -55,42 +58,42 @@ class DdRumWrapper implements DdRumType {
 
     private nativeRum: DdRumType = NativeModules.DdRum;
 
-    startView(key: string, name: string, context: object = {}, timestampMs: number = Date.now()): Promise<void> {
+    startView(key: string, name: string, context: object = {}, timestampMs: number = timeProvider.now()): Promise<void> {
         InternalLog.log("Starting RUM View “" +  name + "” #" + key, SdkVerbosity.DEBUG);
         return this.nativeRum.startView(key, name, context, timestampMs);
     }
 
-    stopView(key: string, context: object = {}, timestampMs: number = Date.now()): Promise<void> {
+    stopView(key: string, context: object = {}, timestampMs: number = timeProvider.now()): Promise<void> {
         InternalLog.log("Stopping RUM View #" + key, SdkVerbosity.DEBUG);
         return this.nativeRum.stopView(key, context, timestampMs);
     }
 
-    startAction(type: string, name: string, context: object = {}, timestampMs: number = Date.now()): Promise<void> {
+    startAction(type: string, name: string, context: object = {}, timestampMs: number = timeProvider.now()): Promise<void> {
         InternalLog.log("Starting RUM Action “" + name + "” (" + type + ")", SdkVerbosity.DEBUG);
         return this.nativeRum.startAction(type, name, context, timestampMs);
     }
 
-    stopAction(context: object = {}, timestampMs: number = Date.now()): Promise<void> {
+    stopAction(context: object = {}, timestampMs: number = timeProvider.now()): Promise<void> {
         InternalLog.log("Stopping current RUM Action", SdkVerbosity.DEBUG);
         return this.nativeRum.stopAction(context, timestampMs);
     }
 
-    addAction(type: string, name: string, context: object = {}, timestampMs: number = Date.now()): Promise<void> {
+    addAction(type: string, name: string, context: object = {}, timestampMs: number = timeProvider.now()): Promise<void> {
         InternalLog.log("Adding RUM Action “" + name + "” (" + type + ")", SdkVerbosity.DEBUG);
         return this.nativeRum.addAction(type, name, context, timestampMs);
     }
 
-    startResource(key: string, method: string, url: string, context: object = {}, timestampMs: number = Date.now()): Promise<void> {
+    startResource(key: string, method: string, url: string, context: object = {}, timestampMs: number = timeProvider.now()): Promise<void> {
         InternalLog.log("Starting RUM Resource #" + key + " " + method + ": " + url, SdkVerbosity.DEBUG);
         return this.nativeRum.startResource(key, method, url, context, timestampMs);
     }
 
-    stopResource(key: string, statusCode: number, kind: string, size: number = -1, context: object = {}, timestampMs: number = Date.now()): Promise<void> {
+    stopResource(key: string, statusCode: number, kind: string, size: number = -1, context: object = {}, timestampMs: number = timeProvider.now()): Promise<void> {
         InternalLog.log("Stopping RUM Resource #" + key + " status:" + statusCode, SdkVerbosity.DEBUG);
         return this.nativeRum.stopResource(key, statusCode, kind, size, context, timestampMs);
     }
 
-    addError(message: string, source: string, stacktrace: string, context: object = {}, timestampMs: number = Date.now()): Promise<void> {
+    addError(message: string, source: string, stacktrace: string, context: object = {}, timestampMs: number = timeProvider.now()): Promise<void> {
         InternalLog.log("Adding RUM Error “" + message + "”", SdkVerbosity.DEBUG);
         let updatedContext: any = context;
         updatedContext["_dd.error.source_type"] = "react-native";


### PR DESCRIPTION
### What does this PR do?

Replaces innacurate `Date.now()` with `performance.now()` whenever possible to compute events' timings
