### PR TITLE
Change docs reference to new expo package

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -17,7 +17,7 @@ yarn install
 
 This repository contains 2 main projects:
 
-* SDK project (in the `packages` folder), which consists of 3 workspaces:
+* SDK project (in the `packages` folder), which consists of 4 workspaces:
     * `codepush`: an integration for the [react-native-code-push](https://github.com/microsoft/react-native-code-push) library.
     * `core`: the core React Native SDK allowing tracking of logs, spans and RUM events.
     * `react-native-navigation`: an integration for the [react-native-navigation](https://github.com/wix/react-native-navigation) library.

--- a/docs/expo_crash_reporting.md
+++ b/docs/expo_crash_reporting.md
@@ -86,5 +86,5 @@ If you are using the `expo-dev-client` and already have the `expo-datadog` plugi
 {{< partial name="whats-next/whats-next.html" >}}
 
 [1]: https://app.datadoghq.com/rum/error-tracking
-[2]: https://github.com/DataDog/dd-sdk-reactnative/blob/develop/expo/README.md
+[2]: https://github.com/DataDog/expo-datadog
 [3]: https://docs.datadoghq.com/real_user_monitoring/reactnative/expo/#usage


### PR DESCRIPTION
### What does this PR do?

Merges same changes as https://github.com/DataDog/dd-sdk-reactnative/pull/338 but in `develop` instead of `main`