### PR TITLE
Update build.gradle

### DIFF
--- a/packages/core/android/build.gradle
+++ b/packages/core/android/build.gradle
@@ -152,7 +152,7 @@ dependencies {
   implementation "org.jetbrains.kotlin:kotlin-stdlib:$kotlin_version"
   compileOnly "com.squareup.okhttp3:okhttp:3.12.13"
   
-  implementation "com.datadoghq:dd-sdk-android:1.16.+"
+  implementation "com.datadoghq:dd-sdk-android:1.16.0"
   testImplementation "org.junit.platform:junit-platform-launcher:1.6.2"
   testImplementation "org.junit.jupiter:junit-jupiter-api:5.6.2"
   testImplementation "org.junit.jupiter:junit-jupiter-engine:5.6.2"


### PR DESCRIPTION
[BUGFIX] Using version "1.16.+" causes gradle to download the latest snapshot which has breaking changes.
Implementing the specific version that wrapper expects fixes this. I've tried this with a package-patch.
