### PR TITLE
Add DatadogProvider.initialize to Jest mock

### DIFF
--- a/packages/core/jest/mock.js
+++ b/packages/core/jest/mock.js
@@ -18,6 +18,7 @@ const actualDatadog = jest.requireActual('@datadog/mobile-react-native');
 const DatadogProviderMock = ({ children }) => {
     return <>{children}</>;
 };
+DatadogProviderMock.initialize = jest.fn().mockResolvedValue()
 
 module.exports = {
     ...actualDatadog,


### PR DESCRIPTION
### What does this PR do?

Adds `DatadogProvider.initialize` to Jest mock

### Motivation

Error when unit testing async initialization
