### PR TITLE
[RUM-9753] Fix crash when calling eventEmitter.sendEvent with invalid bridge after Fast Refresh

### DIFF
--- a/packages/core/ios/Sources/DdSdk.h
+++ b/packages/core/ios/Sources/DdSdk.h
@@ -24,5 +24,6 @@
 @property(nonatomic, strong) DdSdkImplementation *ddSdkImplementation;
 
 + (void)initFromNative;
++ (RCTBridge * _Nullable)latestBridgeReference;
 
 @end

--- a/packages/core/ios/Sources/DdSdk.mm
+++ b/packages/core/ios/Sources/DdSdk.mm
@@ -14,7 +14,12 @@
 
 @implementation DdSdk
 
-@synthesize bridge = _bridge;
+static __weak RCTBridge *s_latestBridge = nil;
+
++ (RCTBridge *)latestBridgeReference {
+    return s_latestBridge;
+}
+
 RCT_EXPORT_MODULE()
 
 RCT_REMAP_METHOD(initialize, withConfiguration:(NSDictionary*)configuration
@@ -105,7 +110,8 @@ RCT_REMAP_METHOD(clearAllData, withResolver:(RCTPromiseResolveBlock)resolve
 - (DdSdkImplementation*)ddSdkImplementation
 {
     if (_ddSdkImplementation == nil) {
-        _ddSdkImplementation = [[DdSdkImplementation alloc] initWithBridge:_bridge];
+        s_latestBridge = self.bridge;
+        _ddSdkImplementation = [[DdSdkImplementation alloc] initWithBridge:self.bridge];
     }
     return _ddSdkImplementation;
 }

--- a/packages/core/ios/Sources/DdSdkNativeInitialization.swift
+++ b/packages/core/ios/Sources/DdSdkNativeInitialization.swift
@@ -151,7 +151,18 @@ public class DdSdkNativeInitialization: NSObject {
             }
         }
         let onSessionStart: RUM.SessionListener = { sessionId, isDiscarded in
-            let body: [String: Any?] = ["sessionId": sessionId, "isDiscarded": isDiscarded]
+            guard
+                let emitter = eventEmitter,
+                let bridge = emitter.bridge,
+                let latestBridge = DdSdk.latestBridgeReference(),
+                bridge === latestBridge
+            else {
+                return
+            }
+            
+            let body: [String: Any?] = [
+                "sessionId": sessionId, "isDiscarded": isDiscarded,
+            ]
             eventEmitter?.sendEvent(withName: "RumSessionStarted", body: body)
         }
         


### PR DESCRIPTION
The issue seems to happen when a reference of `eventEmitter` is kept and used after the `RN bridge` reference is no longer valid. This mostlikely points to a timing issue, so it's hard to reproduce. The likely cause is related to `RN's Fast Refresh` feature.

The code follows these simplified steps:

```
initialize -> enableFeatures -> buildRumConfiguration -> onSessionStart -> eventEmitter.sendEvent(....)
                             -> DatadogSDKWrapper.shared.enableRUM(with: rumConfig)
```

`eventEmitter` is never stored directly, but it is captured inside the `onSessionStart` closure, which means it's retained by the SDK.

When `Fast Refresh` is used, the code follows these steps:

```
initialize -> (exit earlier) // -> This is done in order to prevent reinitialization.
```

But the old `onSessionStart` closure still remains active and still holds the original reference to the original `eventEmitter`.

The crash then happens when Datadog's SDK fires `onSessionStart` closure, because the React Native bridge was destroyed during the `Fast Refresh`, and the bridge reference present in the original `eventEmitter` is now invalid.

We can test this by adding a timeout function to the `buildRUMConfiguration` method that will try to send an event after `x` seconds, and before that time perform a `Fast Refresh`. Something like this should do the trick:

```
DispatchQueue.main.asyncAfter(deadline: .now() + 5.0) { [weak eventEmitter] in
    guard let emitter = eventEmitter else {
        consolePrint("EventEmitter is nil", .critical)
        return
    }

    if let bridge = emitter.bridge, bridge.isValid {
        consolePrint("Bride is still valid", .debug)
        emitter.sendEvent(withName: "RumSessionStarted", body: [
            "sessionId": "test-session-valid",
            "isDiscarded": false
        ])
    } else {
        consolePrint("Bridge is invalid", .critical)
        emitter.sendEvent(withName: "RumSessionStarted", body: [
            "sessionId": "test-session-invalid",
            "isDiscarded": false
        ])
    }
}
```

When testing both expo and bare workflows on version 0.77, the behavior seems to differ.

On expo no crash seems to happen, and as expected the `.sendEvent` also doesn't work, while on bare workflow I could consitentely reproduce the issue as shown below:

```
*** Terminating app due to uncaught exception 'NSInternalInconsistencyException', reason: 'Error when sending event: RumSessionStarted with body: {
    isDiscarded = 0;
    sessionId = "test-session-invalid";
}. RCTCallableJSModules is not set. This is probably because you've explicitly synthesized the RCTCallableJSModules in DdSdk, even though it's inherited from RCTEventEmitter.'
CoreSimulator 1010.10 - Device: iPhone 16 Pro (1DCFF559-8D78-472F-B80E-BDD380288051) - Runtime: iOS 18.2 (22C150) - DeviceType: iPhone 16 Pro
Can't show file for stack frame : <DBGLLDBStackFrame: 0x39211cbd0> - stackNumber:3 - name:uncaught_exception_handler.cold.1. The file path does not exist on the file system: /Users/runner/work/1/s/Source/PLCrashReporter.m
```

