### PR TITLE
[RUM-9771] Fix rum `sessionIdListener` for new architecture

### DIFF
--- a/packages/core/src/DdSdkReactNative.tsx
+++ b/packages/core/src/DdSdkReactNative.tsx
@@ -67,6 +67,7 @@ export class DdSdkReactNative {
         await DdSdkReactNative.initializeNativeSDK(configuration, {
             initializationModeForTelemetry: 'LEGACY'
         });
+
         DdSdkReactNative.enableFeatures(configuration);
     };
 
@@ -77,6 +78,7 @@ export class DdSdkReactNative {
         }
     ): Promise<void> => {
         registerRumSessionIdListener();
+
         if (GlobalState.instance.isInitialized) {
             InternalLog.log(
                 "Can't initialize Datadog, SDK was already initialized",

--- a/packages/core/src/rum/sessionId/sessionIdHelper.ts
+++ b/packages/core/src/rum/sessionId/sessionIdHelper.ts
@@ -3,9 +3,12 @@
  * This product includes software developed at Datadog (https://www.datadoghq.com/).
  * Copyright 2016-Present Datadog, Inc.
  */
+/* eslint-disable @typescript-eslint/no-var-requires */
+/* eslint-disable global-require */
 import { NativeModules } from 'react-native';
 
 import { createNativeEventEmitterForModule } from '../../sdk/EventEmitter/EventEmitter';
+import type { RumSessionStartedEvent } from '../../specs/NativeDdSdk';
 
 const RUM_SESSION_STARTED_EVENT_KEY = 'RumSessionStarted';
 
@@ -17,16 +20,26 @@ let cachedRumSessionId: string | null;
  * the cached Session ID.
  */
 export const registerRumSessionIdListener = () => {
-    const eventEmitter = createNativeEventEmitterForModule(NativeModules.DdSdk);
-    if (eventEmitter.listenerCount(RUM_SESSION_STARTED_EVENT_KEY) > 0) {
-        return;
+    const DdSdkModule =
+        NativeModules.DdSdk || require('../../specs/NativeDdSdk').default;
+    const eventEmitter = createNativeEventEmitterForModule(DdSdkModule);
+    const listenerCount = eventEmitter.listenerCount(
+        RUM_SESSION_STARTED_EVENT_KEY
+    );
+
+    // Always remove old listeners to avoid potential issues with invalid bridge references
+    if (listenerCount > 0) {
+        removeRumSessionIdListeners();
     }
 
-    eventEmitter.addListener(RUM_SESSION_STARTED_EVENT_KEY, (event: any) => {
-        const field = 'sessionId';
-        const sessionId = event[field] as string | null;
-        cachedRumSessionId = sessionId;
-    });
+    eventEmitter.addListener(
+        RUM_SESSION_STARTED_EVENT_KEY,
+        (event: RumSessionStartedEvent) => {
+            const field: keyof RumSessionStartedEvent = 'sessionId';
+            const sessionId = event[field];
+            cachedRumSessionId = sessionId;
+        }
+    );
 };
 
 /**

--- a/packages/core/src/specs/NativeDdSdk.ts
+++ b/packages/core/src/specs/NativeDdSdk.ts
@@ -11,6 +11,11 @@ import { TurboModuleRegistry } from 'react-native';
 /**
  * Do not import this Spec directly, use DdNativeSdkType instead.
  */
+
+export type RumSessionStartedEvent = {
+    sessionId: string | null;
+};
+
 export interface Spec extends TurboModule {
     readonly getConstants: () => {};
 
@@ -81,6 +86,7 @@ export interface Spec extends TurboModule {
      * https://github.com/react-native-community/RNNewArchitectureLibraries/tree/feat/swift-event-emitter?tab=readme-ov-file#codegen-update-codegen-specs)
      */
     addListener: (eventType: string) => void;
+
     removeListeners: (count: number) => void;
 }
 


### PR DESCRIPTION
### What does this PR do?

Fixes bug where event emitter listener for rum session id does not receive events on RN new architecture, due to the fact that we're accessing the native module from the wrong place.

