### PR TITLE
[RUM-9801] Fix main thread initialization warning for `RCTDatadogWebViewManager`

### DIFF
--- a/packages/react-native-webview/ios/Sources/RCTDatadogWebViewManager.mm
+++ b/packages/react-native-webview/ios/Sources/RCTDatadogWebViewManager.mm
@@ -27,6 +27,10 @@ RCT_CUSTOM_VIEW_PROPERTY(allowedHosts, NSArray, RCTDatadogWebView)
     [self setupDatadogWebView:allowedHosts view:view];
 }
 
++ (BOOL)requiresMainQueueSetup {
+    return YES;
+}
+
 // MARK: - Initialization
 - (instancetype)init
 {


### PR DESCRIPTION
### What does this PR do?

FIxes the following warning message some people have been seeing:

> WARN  Module RCTDatadogWebViewManager requires main queue setup since it overrides init but doesn't implement requiresMainQueueSetup. In a future release React Native will default to initializing all native modules on a background thread unless explicitly opted-out of.


