### PR TITLE
fix(core): correct 'occured' -> 'occurred' in DdSdkInternalNativeBridge warning

### DIFF
--- a/packages/core/src/sdk/DatadogInternalBridge/DdSdkInternalNativeBridge.tsx
+++ b/packages/core/src/sdk/DatadogInternalBridge/DdSdkInternalNativeBridge.tsx
@@ -61,7 +61,7 @@ export class DdSdkInternalNativeBridge {
             return true;
         } catch (err) {
             this.errorHandler(
-                `An error occured while registering default listeners for event emitter: ${err}`
+                `An error occurred while registering default listeners for event emitter: ${err}`
             );
             return false;
         }


### PR DESCRIPTION
Console warning emitted when native event-emitter listener registration fails in `packages/core/src/sdk/DatadogInternalBridge/DdSdkInternalNativeBridge.tsx:64` read `An error occured while registering default listeners ...`. String-template-only change.