### PR TITLE
Reproduce RUMS-5828: 128 attribute cap drops legitimate payloads

### DIFF
--- a/packages/core/src/sdk/AttributesEncoding/__tests__/attributesEncoding.test.ts
+++ b/packages/core/src/sdk/AttributesEncoding/__tests__/attributesEncoding.test.ts
@@ -515,4 +515,246 @@ describe('encodeAttributes', () => {
             expect(result.user).toBeUndefined();
         });
     });
+
+    // ------------------------------------------------------------------
+    // RUMS-5828: 128 attribute cap drops legitimate payloads
+    // ------------------------------------------------------------------
+    //
+    // These tests document the customer-expected behavior. They MUST fail
+    // today because the SDK enforces MAX_ATTRIBUTES = 128 in helpers.ts.
+    // They will pass once the cap is raised / removed / scoped to user
+    // attributes only — at which point they become a regression contract
+    // for the corrected behavior.
+    //
+    // Customer report: DdLogs.info(...) with a flat array of 22 small
+    // objects (6 props each = 132 leaves) is silently truncated. From the
+    // customer's perspective the cap mechanism IS the bug — these tests
+    // assert what the customer reasonably expects.
+    describe('RUMS-5828: 128 attribute cap drops legitimate payloads', () => {
+        it('preserves all 132 leaves of the customer-reported nested-array payload', () => {
+            // Customer minimal repro (Slack thread / Jira RUMS-5828):
+            //   DdLogs.info('!!! test', { basicTestArray: [{a..f}] x 22 })
+            // 22 items x 6 props = 132 flattened leaves.
+            const basicTestArray = Array.from({ length: 22 }, () => ({
+                a: 1,
+                b: 2,
+                c: 3,
+                d: 4,
+                e: 5,
+                f: 6
+            }));
+
+            const result = encodeAttributes({ basicTestArray });
+
+            // Customer expectation: the entire payload survives encoding.
+            // The single top-level `basicTestArray` attribute should be
+            // preserved with ALL 22 nested objects, each holding all 6
+            // properties. None of `a..f` should be dropped on any item.
+            expect(result.basicTestArray).toBeDefined();
+            expect(Array.isArray(result.basicTestArray)).toBe(true);
+            expect((result.basicTestArray as unknown[]).length).toBe(22);
+            for (let i = 0; i < 22; i++) {
+                expect((result.basicTestArray as any)[i]).toEqual({
+                    a: 1,
+                    b: 2,
+                    c: 3,
+                    d: 4,
+                    e: 5,
+                    f: 6
+                });
+            }
+
+            // No "Attribute limit" warning should fire for this payload —
+            // it represents a normal analytics event, not abusive input.
+            const limitWarnings = (warn as jest.Mock).mock.calls.filter(
+                ([msg]: [string]) =>
+                    typeof msg === 'string' && msg.includes('Attribute limit')
+            );
+            expect(limitWarnings).toHaveLength(0);
+        });
+
+        it('preserves a flat 129-key input without dropping any attribute', () => {
+            // Boundary documentation: a flat input one over the current
+            // cap (129) should still be preserved end-to-end. Today the
+            // cap silently drops the 129th key (k128). When the cap is
+            // raised to 256 (or removed), this expectation holds.
+            const input: Record<string, number> = {};
+            for (let i = 0; i < 129; i++) {
+                input[`k${i}`] = i;
+            }
+
+            const result = encodeAttributes(input);
+
+            expect(Object.keys(result)).toHaveLength(129);
+            expect(result.k128).toBe(128);
+
+            const limitWarnings = (warn as jest.Mock).mock.calls.filter(
+                ([msg]: [string]) =>
+                    typeof msg === 'string' && msg.includes('Attribute limit')
+            );
+            expect(limitWarnings).toHaveLength(0);
+        });
+
+        it('does not let internal _dd.* attributes consume the user-attribute budget', () => {
+            // attributesEncoding.ts:35 increments numOfAttributes on the
+            // _dd.* shortcut path, which means SDK-internal metadata
+            // shrinks the headroom for user attributes. Customer
+            // expectation: SDK-internal metadata is overhead the SDK
+            // controls, not part of the user's attribute budget.
+            const input: Record<string, unknown> = { '_dd.foo': 'bar' };
+            for (let i = 0; i < 128; i++) {
+                input[`k${i}`] = i;
+            }
+
+            const result = encodeAttributes(input);
+
+            // All 128 user attributes preserved, plus the _dd.foo metadata.
+            expect(result['_dd.foo']).toBe('bar');
+            for (let i = 0; i < 128; i++) {
+                expect(result[`k${i}`]).toBe(i);
+            }
+            expect(Object.keys(result)).toHaveLength(129);
+
+            const limitWarnings = (warn as jest.Mock).mock.calls.filter(
+                ([msg]: [string]) =>
+                    typeof msg === 'string' && msg.includes('Attribute limit')
+            );
+            expect(limitWarnings).toHaveLength(0);
+        });
+    });
+
+    // ------------------------------------------------------------------
+    // RUMS-5828: current behavior pin (regression contract)
+    // ------------------------------------------------------------------
+    //
+    // These tests document the EXACT present-day buggy behavior so that
+    // any future change to the cap mechanism is intentional, not
+    // incidental. They pass today against MAX_ATTRIBUTES = 128 and SHOULD
+    // be deleted (or updated) at the same time as the fix that removes
+    // / raises / re-scopes the cap. They are paired with the failing
+    // tests above so reviewers can see both sides of the contract.
+    describe('RUMS-5828: current behavior pin (regression contract)', () => {
+        it('CURRENT BEHAVIOR: drops the entire basicTestArray for the 132-leaf customer payload', () => {
+            // Pins the present-day cascade where each of the 22 nested
+            // objects increments numOfAttributes via addEncodedAttribute,
+            // overflowing the 128 cap before the array wrapper itself
+            // can be written. Net effect: result is empty {}.
+            const basicTestArray = Array.from({ length: 22 }, () => ({
+                a: 1,
+                b: 2,
+                c: 3,
+                d: 4,
+                e: 5,
+                f: 6
+            }));
+
+            const result = encodeAttributes({ basicTestArray });
+
+            // The cap is hit before the outer array attribute is written,
+            // so even basicTestArray itself is dropped.
+            expect(Object.keys(result)).toHaveLength(0);
+            expect(result.basicTestArray).toBeUndefined();
+
+            // One aggregate "limit reached" warn + one warn for the
+            // outer basicTestArray drop + four inner-prop drop warns
+            // (path 'c', 'd', 'e', 'f' from item index 21 — recursion
+            // into a nested object uses an empty base path, so the
+            // dropped inner-prop warns reference single-segment keys).
+            const limitReachedWarns = (warn as jest.Mock).mock.calls.filter(
+                ([msg]: [string]) =>
+                    typeof msg === 'string' &&
+                    msg.startsWith('Attribute limit of 128 reached')
+            );
+            expect(limitReachedWarns).toHaveLength(1);
+
+            const droppedAttrWarns = (warn as jest.Mock).mock.calls.filter(
+                ([msg]: [string]) =>
+                    typeof msg === 'string' &&
+                    msg.startsWith('Dropped attribute at')
+            );
+            expect(droppedAttrWarns).toHaveLength(5);
+
+            // basicTestArray wrapper itself is dropped.
+            expect(
+                droppedAttrWarns.some(([msg]: [string]) =>
+                    msg.includes("'basicTestArray'")
+                )
+            ).toBe(true);
+            // Inner-prop drops (last 4 props of the 22nd item).
+            for (const k of ['c', 'd', 'e', 'f']) {
+                expect(
+                    droppedAttrWarns.some(([msg]: [string]) =>
+                        msg.includes(`'${k}'`)
+                    )
+                ).toBe(true);
+            }
+        });
+
+        it('CURRENT BEHAVIOR: a flat 128-key input passes unchanged with no warnings', () => {
+            const input: Record<string, number> = {};
+            for (let i = 0; i < 128; i++) {
+                input[`k${i}`] = i;
+            }
+
+            const result = encodeAttributes(input);
+
+            expect(Object.keys(result)).toHaveLength(128);
+            expect(result.k0).toBe(0);
+            expect(result.k127).toBe(127);
+            expect(warn).not.toHaveBeenCalled();
+        });
+
+        it('CURRENT BEHAVIOR: a flat 129-key input is capped at 128 with one limit warn and one drop warn', () => {
+            const input: Record<string, number> = {};
+            for (let i = 0; i < 129; i++) {
+                input[`k${i}`] = i;
+            }
+
+            const result = encodeAttributes(input);
+
+            expect(Object.keys(result)).toHaveLength(128);
+            expect(result.k127).toBe(127);
+            expect(result.k128).toBeUndefined();
+
+            const limitReachedWarns = (warn as jest.Mock).mock.calls.filter(
+                ([msg]: [string]) =>
+                    typeof msg === 'string' &&
+                    msg.startsWith('Attribute limit of 128 reached')
+            );
+            expect(limitReachedWarns).toHaveLength(1);
+
+            const droppedAttrWarns = (warn as jest.Mock).mock.calls.filter(
+                ([msg]: [string]) =>
+                    typeof msg === 'string' &&
+                    msg.startsWith('Dropped attribute at')
+            );
+            expect(droppedAttrWarns).toHaveLength(1);
+            expect(droppedAttrWarns[0][0]).toContain("'k128'");
+        });
+
+        it('CURRENT BEHAVIOR: _dd.* attributes consume one slot of the 128-attribute budget', () => {
+            // Pins the attributesEncoding.ts:35 increment on the _dd.*
+            // shortcut path — adding one _dd.* attribute drops one user
+            // attribute when the user side has 128 keys.
+            const input: Record<string, unknown> = { '_dd.foo': 'bar' };
+            for (let i = 0; i < 128; i++) {
+                input[`k${i}`] = i;
+            }
+
+            const result = encodeAttributes(input);
+
+            expect(Object.keys(result)).toHaveLength(128);
+            expect(result['_dd.foo']).toBe('bar');
+            // 127 user attributes preserved, last one (k127) dropped.
+            expect(result.k126).toBe(126);
+            expect(result.k127).toBeUndefined();
+
+            const limitReachedWarns = (warn as jest.Mock).mock.calls.filter(
+                ([msg]: [string]) =>
+                    typeof msg === 'string' &&
+                    msg.startsWith('Attribute limit of 128 reached')
+            );
+            expect(limitReachedWarns).toHaveLength(1);
+        });
+    });
 });


### PR DESCRIPTION
## Reproduction for RUMS-5828

### Issue Summary
The React Native SDK's v3 attribute encoder caps every event at 128 leaf attributes via `MAX_ATTRIBUTES = 128` in `packages/core/src/sdk/AttributesEncoding/helpers.ts`, silently dropping any leaves beyond the cap. Realistic payloads with arrays of small objects (e.g. 22 items × 6 props = 132 leaves) trigger the cap during normal `DdLogs.info(...)` usage. In the nested-array case the overflow happens *before* the array wrapper itself is written, so the entire top-level attribute is dropped — the customer's payload reaches the native layer as `{}`.

### Reproduction Tests
- Unit tests: 7 (in `packages/core/src/sdk/AttributesEncoding/__tests__/attributesEncoding.test.ts`)
- Integration tests: 0

### What the Tests Prove
Three new tests in the `RUMS-5828: 128 attribute cap drops legitimate payloads` describe block fail today, documenting the bug as the customer experiences it:
1. A nested-array payload of 132 leaves (22 × 6-prop objects) yields an empty result instead of preserving all 22 items × 6 props.
2. A flat 129-key input is capped at 128 instead of being preserved.
3. Internal `_dd.*` attributes consume slots in the user-attribute budget instead of being SDK overhead.

Four companion tests under `RUMS-5828: current behavior pin (regression contract)` describe the exact present-day semantics; they pass today and serve as a regression contract against accidental future changes:
- The 132-leaf customer payload yields an empty `{}` plus 1 limit-reached warn + 5 dropped-attribute warns (4 inner-prop drops on the 22nd item: `'c'`, `'d'`, `'e'`, `'f'`, plus 1 wrapper drop for `'basicTestArray'`).
- A flat 128-key input passes unchanged with no warnings.
- A flat 129-key input is capped at 128 with one limit warn and one drop warn for `'k128'`.
- `_dd.*` attributes consume one slot of the 128-attribute budget.

### Root Cause Analysis
The v3 attribute-encoding rewrite (introduced in #1008, commit a3c778c) added a hard cap of 128 in `addEncodedAttribute`. The cap was chosen as a defensive halving of the documented 256-attribute platform limit because `validateAttributes` is called twice per event-path. With recursive flattening (arrays of objects expanded as nested objects whose primitive properties each call `addEncodedAttribute` and increment `numOfAttributes`), legitimate analytics payloads can exceed 128 leaves and trigger silent drops. In the nested-array case, the inner-leaf increments overflow the cap *before* the outer array wrapper is written, so even the top-level attribute itself is dropped.

### Call Chain
`DdLogs.info(message, context)` → `DdLogsWrapper.log(...)` → `encodeAttributes(event.context)` → `encodeAttributesInPlace(value, out, path, encoders, context)` (recurses into arrays/objects) → for each item in the array, `normalize(item)` → recursive `encodeAttributesInPlace(item, nested, [], encoders, context)` → `addEncodedAttribute(nested, [k], v, context)` per leaf → if `context.numOfAttributes >= 128`: emit warns and drop. After all items processed, the outer-array `addEncodedAttribute(out, ['basicTestArray'], normalizedArray, context)` is also dropped because `numOfAttributes` is now at the cap.

### Regression Evidence
On source:react-native, v3.3.0 (released ~mid-April 2026, ~3.9M sessions over 30d) introduced the JS-side attribute encoder cap of 128 leaves per event in commit a3c778c (PR #1008, `Limit encoded attributes to 128`). The platform's documented per-event limit is 256 attributes (with backend feature-flag `rum_parse_big_events` extending to 2048). The RN cap is intentionally conservative versus the backend ceiling. No new failure mode in `logs.rum.telemetry.errors` for v3.3.0 vs v3.2.0 or v2.14.3 — the attribute-drop is reported only as a JS `console.warn` and is not measurable in the public-side telemetry metric family.

### Failure Output
```
encodeAttributes
  RUMS-5828: 128 attribute cap drops legitimate payloads
    ✕ preserves all 132 leaves of the customer-reported nested-array payload
        expect(received).toBeDefined()
        Received: undefined
        > 553 |             expect(result.basicTestArray).toBeDefined();
    ✕ preserves a flat 129-key input without dropping any attribute
        expect(received).toHaveLength(expected)
        Expected length: 129
        Received length: 128
        > 588 |             expect(Object.keys(result)).toHaveLength(129);
    ✕ does not let internal _dd.* attributes consume the user-attribute budget
        expect(received).toBe(expected) // Object.is equality
        Expected: 127
        Received: undefined
        > 614 |                 expect(result[`k${i}`]).toBe(i);
```

---
*Generated by rum:tee-triage-insights*
