### PR TITLE
Reproduce RUMS-5852: FpsFrameCallback must not dispatch via UI-thread executor

### DIFF
--- a/packages/core/android/src/test/kotlin/com/datadog/reactnative/FpsFrameCallbackTest.kt
+++ b/packages/core/android/src/test/kotlin/com/datadog/reactnative/FpsFrameCallbackTest.kt
@@ -1,0 +1,78 @@
+/*
+ * Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
+ * This product includes software developed at Datadog (https://www.datadoghq.com/).
+ * Copyright 2016-Present Datadog, Inc.
+ */
+
+package com.datadog.reactnative
+
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.extension.ExtendWith
+import org.junit.jupiter.api.extension.Extensions
+import org.mockito.Mock
+import org.mockito.junit.jupiter.MockitoExtension
+import org.mockito.junit.jupiter.MockitoSettings
+import org.mockito.kotlin.any
+import org.mockito.kotlin.never
+import org.mockito.kotlin.verify
+import org.mockito.quality.Strictness
+
+/**
+ * Reproduction tests for RUMS-5852.
+ *
+ * On Android, React Native long_task / frozen_frame detection never fires for JS-thread hangs
+ * because [FpsFrameCallback.start]/[FpsFrameCallback.stop] hop back to the UI thread via
+ * [UiThreadExecutor.runOnUiThread] before posting the FrameCallback. Android
+ * `Choreographer.getInstance()` is thread-local and Looper-bound, so the FrameCallback ticks on
+ * the main thread regardless of JS state. The frame deltas reflect UI VSYNC cadence and never
+ * cross the JS long-task threshold.
+ *
+ * These are negative-existence assertions: the tests verify that [UiThreadExecutor.runOnUiThread]
+ * MUST NOT be invoked by [FpsFrameCallback.start]/[stop]. They fail on develop because the
+ * current implementation does invoke the UI thread executor; they will pass after the fix routes
+ * dispatch through a JS-thread executor instead.
+ */
+@Extensions(
+    ExtendWith(MockitoExtension::class)
+)
+@MockitoSettings(strictness = Strictness.LENIENT)
+internal class FpsFrameCallbackTest {
+
+    @Mock
+    lateinit var mockUiThreadExecutor: UiThreadExecutor
+
+    private val noopFrameRateCallback: (Double) -> Unit = { _ -> }
+
+    private lateinit var testedFrameCallback: FpsFrameCallback
+
+    @BeforeEach
+    fun `set up`() {
+        testedFrameCallback = FpsFrameCallback(
+            noopFrameRateCallback,
+            mockUiThreadExecutor
+        )
+    }
+
+    @Test
+    fun `M not invoke uiThreadExecutor W start()`() {
+        // When
+        testedFrameCallback.start()
+
+        // Then — see RUMS-5852: posting to the Choreographer must happen on the JS thread,
+        // not the UI thread. Today's implementation hops to the UI thread, which binds
+        // Choreographer ticks to UI VSYNC cadence and prevents JS-thread hangs from being
+        // detected as long_tasks / frozen_frames.
+        verify(mockUiThreadExecutor, never()).runOnUiThread(any())
+    }
+
+    @Test
+    fun `M not invoke uiThreadExecutor W stop()`() {
+        // When
+        testedFrameCallback.stop()
+
+        // Then — see RUMS-5852: removing the FrameCallback must happen on the same thread it
+        // was posted on (the JS thread), not the UI thread.
+        verify(mockUiThreadExecutor, never()).runOnUiThread(any())
+    }
+}


### PR DESCRIPTION
## Reproduction for RUMS-5852

### Issue Summary
On Android, React Native long_task / frozen_frame detection never fires for JS-thread hangs because `FpsFrameCallback.start()` hops back to the UI thread via `uiThreadExecutor.runOnUiThread` before posting the FrameCallback. Android `Choreographer.getInstance()` is thread-local, so the FrameCallback ticks on the main thread regardless of JS state — the measured frame deltas reflect UI VSYNC cadence and never cross the JS long-task threshold.

### Reproduction Tests
- Unit tests: 2 (in `packages/core/android/src/test/kotlin/com/datadog/reactnative/FpsFrameCallbackTest.kt`)
- Integration tests: 0

### What the Tests Prove
The new tests `M not invoke uiThreadExecutor W start()` and `M not invoke uiThreadExecutor W stop()` assert that `FpsFrameCallback` must not dispatch through `UiThreadExecutor.runOnUiThread`. They fail on develop because the current implementation calls exactly that. After the corrective fix (route through a JS-thread executor instead), the tests pass.

### Root Cause Analysis
`FpsFrameCallback.start()/stop()` (`FrameRateProvider.kt:46-58`) wraps `Choreographer.getInstance(); postFrameCallback(this)` (and the matching remove) in `uiThreadExecutor.runOnUiThread { ... }`. Because `Choreographer.getInstance()` is thread-local and Looper-bound on Android, this binds the FrameCallback to the main Looper's Choreographer. `doFrame()` therefore ticks every VSYNC on the UI thread regardless of JS-thread state, so a JS hang produces ~16ms frame deltas (UI thread is unaffected) and the long-task threshold is never tripped. iOS does it correctly via `jsQueue.async { CADisplayLink.add(to: .current, forMode: .common) }` where `.current = JS thread RunLoop`. The wrapper at `DdSdkImplementation.kt:331` already calls `reactContext.runOnJSQueueThread { frameRateProvider.start() }` — signaling original JS-thread design intent that `FpsFrameCallback.start()` defeats by re-hopping to the UI thread.

### Call Chain
- `DdSdkImplementation.initialize()` -> `createFrameRateProvider()` (`DdSdkImplementation.kt:65`)
- `createFrameRateProvider()` constructs `FrameRateProvider(callback, uiThreadExecutor)`; `reactContext.runOnJSQueueThread { frameRateProvider.start() }` (`DdSdkImplementation.kt:326-336`)
- `FrameRateProvider.start()` -> `frameCallback.start()` (`FrameRateProvider.kt:20-23`)
- `FpsFrameCallback.start()` -> `uiThreadExecutor.runOnUiThread { Choreographer.getInstance(); postFrameCallback(this) }` (`FrameRateProvider.kt:46-51`) — BUG
- Choreographer ticks on UI thread; `doFrame()` fires regardless of JS thread state
- `buildFrameTimeCallback` emits long_task with `action="javascript"` but reads UI thread cadence (`DdSdkImplementation.kt:352-367`)

### Failure Output
```
FpsFrameCallbackTest > M not invoke uiThreadExecutor W start()() FAILED
    org.mockito.exceptions.verification.NeverWantedButInvoked at FpsFrameCallbackTest.kt:66
    mockUiThreadExecutor.runOnUiThread(<any java.lang.Runnable>);
    Never wanted here:
    -> at FpsFrameCallbackTest.M not invoke uiThreadExecutor W start()(FpsFrameCallbackTest.kt:66)
    But invoked here:
    -> at FpsFrameCallback.start(FrameRateProvider.kt:47) with arguments: [Lambda]

FpsFrameCallbackTest > M not invoke uiThreadExecutor W stop()() FAILED
    org.mockito.exceptions.verification.NeverWantedButInvoked at FpsFrameCallbackTest.kt:76
    mockUiThreadExecutor.runOnUiThread(<any java.lang.Runnable>);
    Never wanted here:
    -> at FpsFrameCallbackTest.M not invoke uiThreadExecutor W stop()(FpsFrameCallbackTest.kt:76)
    But invoked here:
    -> at FpsFrameCallback.stop(FrameRateProvider.kt:54) with arguments: [Lambda]

176 tests completed, 2 failed
```

The 174 pre-existing tests continue to pass. ktlintCheck on the new file passes. detekt findings on the project are pre-existing and unrelated to the new test file.

---
*Generated by rum:tee-triage-insights*
