### PR TITLE
Fix Android flags core lookup

### DIFF
--- a/packages/core/android/src/main/kotlin/com/datadog/reactnative/DdFlagsImplementation.kt
+++ b/packages/core/android/src/main/kotlin/com/datadog/reactnative/DdFlagsImplementation.kt
@@ -26,9 +26,12 @@ import java.util.Locale
  * The entry point to use Datadog's Flags feature.
  */
 class DdFlagsImplementation(
-    private val sdkCore: SdkCore = Datadog.getInstance(),
+    private val sdkCoreOverride: SdkCore? = null,
 ) {
     private val clients: MutableMap<String, FlagsClient> = mutableMapOf()
+
+    private val sdkCore: SdkCore
+        get() = sdkCoreOverride ?: Datadog.getInstance()
 
     /**
      * Enable the Flags feature with the provided configuration.

--- a/packages/core/android/src/test/kotlin/com/datadog/reactnative/DdFlagsImplementationTest.kt
+++ b/packages/core/android/src/test/kotlin/com/datadog/reactnative/DdFlagsImplementationTest.kt
@@ -1,0 +1,77 @@
+/*
+ * Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
+ * This product includes software developed at Datadog (https://www.datadoghq.com/).
+ * Copyright 2016-Present Datadog, Inc.
+ */
+
+package com.datadog.reactnative
+
+import com.datadog.android.Datadog
+import com.datadog.android.api.SdkCore
+import com.datadog.android.flags.Flags
+import com.datadog.android.flags.FlagsConfiguration
+import com.datadog.tools.unit.toReadableMap
+import com.facebook.react.bridge.Promise
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.extension.ExtendWith
+import org.junit.jupiter.api.extension.Extensions
+import org.mockito.Mock
+import org.mockito.Mockito
+import org.mockito.junit.jupiter.MockitoExtension
+import org.mockito.kotlin.any
+import org.mockito.kotlin.mock
+import org.mockito.kotlin.same
+import org.mockito.kotlin.verify
+
+@Extensions(
+    ExtendWith(MockitoExtension::class)
+)
+internal class DdFlagsImplementationTest {
+
+    @Mock
+    lateinit var mockPromise: Promise
+
+    @Test
+    fun `M not resolve SDK core W constructed`() {
+        // Given
+        val datadogMock = Mockito.mockStatic(Datadog::class.java)
+
+        try {
+            // When
+            DdFlagsImplementation()
+
+            // Then
+            datadogMock.verifyNoInteractions()
+        } finally {
+            datadogMock.close()
+        }
+    }
+
+    @Test
+    fun `M resolve current SDK core W enable() called after construction`() {
+        // Given
+        val staleCore = mock<SdkCore>()
+        val initializedCore = mock<SdkCore>()
+        var currentCore = staleCore
+        val configuration = mapOf("enabled" to true).toReadableMap()
+        val datadogMock = Mockito.mockStatic(Datadog::class.java)
+        val flagsMock = Mockito.mockStatic(Flags::class.java)
+
+        try {
+            datadogMock.`when`<SdkCore> { Datadog.getInstance() }.thenAnswer { currentCore }
+            flagsMock.`when`<Unit> { Flags.enable(any<FlagsConfiguration>(), any()) }.then { }
+            val testedImplementation = DdFlagsImplementation()
+            currentCore = initializedCore
+
+            // When
+            testedImplementation.enable(configuration, mockPromise)
+
+            // Then
+            flagsMock.verify { Flags.enable(any<FlagsConfiguration>(), same(initializedCore)) }
+            verify(mockPromise).resolve(null)
+        } finally {
+            flagsMock.close()
+            datadogMock.close()
+        }
+    }
+}


### PR DESCRIPTION
## Motivation

Android React Native apps can construct the `DdFlags` native module while the JavaScript bundle is still evaluating, before `DdSdk.initialize` has initialized the Datadog SDK. The Android flags implementation captured `Datadog.getInstance()` in the constructor, so that early construction could pin a no-op core for the lifetime of the process. In that state, enabling Flags had no effect and OpenFeature clients fell back to defaults even after the SDK initialized.

## Changes

This PR changes the Android flags implementation to keep test injection support while resolving the Datadog `SdkCore` lazily when Flags are enabled or a native Flags client is created. That makes the Android path match the intended initialization order for React Native and Expo apps: module construction can happen early, but the core used for Flags comes from the initialized SDK when the app calls `DdFlags.enable()` and sets up OpenFeature.

A focused Kotlin regression test covers both parts of the failure mode: constructing `DdFlagsImplementation` no longer calls `Datadog.getInstance()`, and an implementation constructed while a stale core is current uses the later initialized core when `enable()` is called.

## Decisions

The fix intentionally stays inside the Android native implementation instead of adding JavaScript ordering requirements or Expo-specific setup. The public JS API and OpenFeature provider behavior remain unchanged, and existing tests can still inject an explicit `SdkCore` override.

Validation: `git diff --check` passed. I attempted `./gradlew testDebugUnitTest --tests com.datadog.reactnative.DdFlagsImplementationTest`; local execution is blocked because this environment has no Android SDK configured (`ANDROID_HOME` is unset).