### PR TITLE
[iOS] Drop network error events of resources marked as dropped (#1338)

### DIFF
--- a/packages/core/ios/Sources/DdSdkNativeInitialization.swift
+++ b/packages/core/ios/Sources/DdSdkNativeInitialization.swift
@@ -231,6 +231,14 @@ public class DdSdkNativeInitialization: NSObject {
                 }
                 return actionEvent
             },
+            errorEventMapper: { errorEvent in
+                if errorEvent.context?.contextInfo[InternalConfigurationAttributes.dropResource]
+                    != nil
+                {
+                    return nil
+                }
+                return errorEvent
+            },
             onSessionStart: DdSdkSessionStartedListener.instance.rumSessionListener,
             customEndpoint: customRUMEndpointURL,
             trackMemoryWarnings: rumConfig.trackMemoryWarnings

--- a/packages/core/ios/Tests/DdSdkTests.swift
+++ b/packages/core/ios/Tests/DdSdkTests.swift
@@ -1609,6 +1609,24 @@ class DdSdkTests: XCTestCase {
         XCTAssertNotNil(mappedEvent)
     }
 
+    func testDropsErrorMarkedAsDropped() throws {
+        let configuration: DdSdkConfiguration = .mockAny()
+
+        let ddConfig = DdSdkNativeInitialization().buildRumConfiguration(
+            configuration: configuration
+        )
+
+        let errorEventMapper = try XCTUnwrap(ddConfig.errorEventMapper)
+
+        let mockDroppedErrorEvent = RUMErrorEvent.mockRandomDropped()
+        let mappedDroppedEvent = errorEventMapper(mockDroppedErrorEvent)
+        XCTAssertNil(mappedDroppedEvent)
+
+        let mockErrorEvent = RUMErrorEvent.mockRandom()
+        let mappedEvent = errorEventMapper(mockErrorEvent)
+        XCTAssertNotNil(mappedEvent)
+    }
+
     func testReactNativeThreadMonitorsRunOnBridge() throws {
         let bridge = DispatchQueueMock()
         let mockJSRefreshRateMonitor = MockJSRefreshRateMonitor()

--- a/packages/core/ios/Tests/RUMMocks.swift
+++ b/packages/core/ios/Tests/RUMMocks.swift
@@ -514,6 +514,94 @@ extension RUMActionEvent: RandomMockable {
     }
 }
 
+extension RUMErrorEvent: RandomMockable {
+    static func mockRandomDropped() -> RUMErrorEvent {
+        return RUMErrorEvent(
+            dd: .init(
+                browserSdkVersion: nil,
+                configuration: nil,
+                session: .init(plan: .plan1, sessionPrecondition: nil)
+            ),
+            application: .init(id: .mockRandom()),
+            buildId: nil,
+            buildVersion: nil,
+            ciTest: nil,
+            connectivity: .mockRandom(),
+            container: nil,
+            context: .init(contextInfo: ["_dd.resource.drop_resource": true] ),
+            date: .mockRandom(),
+            device: .mockRandom(),
+            display: nil,
+            error: .init(
+                isCrash: false,
+                message: .mockRandom(),
+                source: .network,
+                stack: .mockRandom()
+            ),
+            os: .mockRandom(),
+            service: .mockRandom(),
+            session: .init(
+                hasReplay: nil,
+                id: .mockRandom(),
+                type: .user
+            ),
+            source: .ios,
+            synthetics: nil,
+            usr: .mockRandom(),
+            version: .mockRandom(),
+            view: .init(
+                id: .mockRandom(),
+                inForeground: .random(),
+                referrer: .mockRandom(),
+                url: .mockRandom()
+            )
+        )
+    }
+
+    static func mockRandom() -> RUMErrorEvent {
+        return RUMErrorEvent(
+            dd: .init(
+                browserSdkVersion: nil,
+                configuration: nil,
+                session: .init(plan: .plan1, sessionPrecondition: nil)
+            ),
+            application: .init(id: .mockRandom()),
+            buildId: nil,
+            buildVersion: nil,
+            ciTest: nil,
+            connectivity: .mockRandom(),
+            container: nil,
+            context: nil,
+            date: .mockRandom(),
+            device: .mockRandom(),
+            display: nil,
+            error: .init(
+                isCrash: false,
+                message: .mockRandom(),
+                source: .network,
+                stack: .mockRandom()
+            ),
+            os: .mockRandom(),
+            service: .mockRandom(),
+            session: .init(
+                hasReplay: nil,
+                id: .mockRandom(),
+                type: .user
+            ),
+            source: .ios,
+            synthetics: nil,
+            usr: .mockRandom(),
+            version: .mockRandom(),
+            view: .init(
+                id: .mockRandom(),
+                inForeground: .random(),
+                referrer: .mockRandom(),
+                url: .mockRandom()
+            )
+        )
+    }
+}
+
 // MARK: - URLRequest Mocks
 
 extension URLRequest {


### PR DESCRIPTION
### What does this PR do?

Registers the missing native `errorEventMapper` in `DdSdkNativeInitialization.swift`, mirroring the existing `resourceEventMapper` and `actionEventMapper`: RUM error events whose context carries the internal `_dd.resource.drop_resource` marker are dropped before being sent to Datadog.

Adds `RUMErrorEvent` mocks and a `testDropsErrorMarkedAsDropped` unit test, mirroring the existing resource/action mapper tests.

### Motivation

Implements the proposal discussed in #1338. On iOS, requests tracked by the JS layer are tracked a second time by the native `URLSession` instrumentation; the duplicated **resource** and **action** events are dropped via the `drop_resource` marker, but the **error** events emitted for the same failed requests are not — they always reach Datadog and cannot be filtered from application code (the JS `errorEventMapper` never sees them, and no native hook is exposed). In our production app this represents ~583k duplicated error events per month.

This change aligns iOS with the current Android behavior, where JS-tracked requests produce no native error events. The failure information is preserved: the JS layer still reports the resource with `status_code: 0`.

### Additional Notes

- We have been running this exact mapper as a `patch-package` patch on `@datadog/mobile-react-native@3.4.0`: it builds and removes exactly the marked duplicates; error events from natively-issued requests (no JS mirror, no marker) are untouched.
- Opened as draft pending maintainer feedback on #1338 — happy to adjust to an opt-in configuration flag instead if you consider the current behavior intentional.