### PR TITLE
[RUM-18130] Migrate test jobs to macOS Sequoia ARM64 runners

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -7,6 +7,7 @@ variables:
     GIT_DEPTH: 5
     DEVELOP_BRANCH: 'develop'
     DEVELOPER_DIR: '/Applications/Xcode-16.4.0.app/Contents/Developer'
+    IOS_SIMULATOR_DESTINATION: 'platform=iOS Simulator,OS=18.5,name=iPhone 16 Pro Max'
     ANDROID_SDK_VERSION: 'commandlinetools-mac-11076708_latest'
     EMULATOR_NAME: 'android_emulator'
     ANDROID_ARCH: 'arm64-v8a'
@@ -103,7 +104,7 @@ test:native-ios:
     script:
         - yarn
         - (cd example/ios && RCT_NEW_ARCH_ENABLED=0 pod install --repo-update)
-        - set -o pipefail && xcodebuild -workspace example/ios/DdSdkReactNativeExample.xcworkspace -scheme DatadogSDKReactNative test -destination "platform=iOS Simulator,OS=18.5,name=iPhone 16 Pro Max" | xcbeautify
+        - set -o pipefail && xcodebuild -workspace example/ios/DdSdkReactNativeExample.xcworkspace -scheme DatadogSDKReactNative test -destination "$IOS_SIMULATOR_DESTINATION" | xcbeautify
 
 test:native-ios-sr:
     tags: ['macos:sequoia-arm64', 'specific:true']
@@ -114,7 +115,7 @@ test:native-ios-sr:
     script:
         - yarn
         - (cd example/ios && RCT_NEW_ARCH_ENABLED=0 pod install --repo-update)
-        - set -o pipefail && xcodebuild -workspace example/ios/DdSdkReactNativeExample.xcworkspace -scheme DatadogSDKReactNativeSessionReplay test -destination "platform=iOS Simulator,OS=18.5,name=iPhone 16 Pro Max" | xcbeautify
+        - set -o pipefail && xcodebuild -workspace example/ios/DdSdkReactNativeExample.xcworkspace -scheme DatadogSDKReactNativeSessionReplay test -destination "$IOS_SIMULATOR_DESTINATION" | xcbeautify
 
 test:native-ios-newarch:
     tags: ['macos:sequoia-arm64', 'specific:true']
@@ -125,7 +126,7 @@ test:native-ios-newarch:
     script:
         - yarn
         - (cd example-new-architecture/ios && RCT_NEW_ARCH_ENABLED=1 pod install --repo-update)
-        - set -o pipefail && xcodebuild -workspace example-new-architecture/ios/DdSdkReactNativeExample.xcworkspace -scheme DatadogSDKReactNative test -destination "platform=iOS Simulator,OS=18.5,name=iPhone 16 Pro Max" | xcbeautify
+        - set -o pipefail && xcodebuild -workspace example-new-architecture/ios/DdSdkReactNativeExample.xcworkspace -scheme DatadogSDKReactNative test -destination "$IOS_SIMULATOR_DESTINATION" | xcbeautify
 
 benchmark:
     stage: benchmark

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -6,6 +6,7 @@ include:
 variables:
     GIT_DEPTH: 5
     DEVELOP_BRANCH: 'develop'
+    DEVELOPER_DIR: '/Applications/Xcode-16.4.0.app/Contents/Developer'
     ANDROID_SDK_VERSION: 'commandlinetools-mac-11076708_latest'
     EMULATOR_NAME: 'android_emulator'
     ANDROID_ARCH: 'arm64-v8a'

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -45,7 +45,7 @@ stages:
 # TESTS
 
 test:lint:
-    tags: ['macos:sonoma', 'specific:true']
+    tags: ['macos:sequoia-arm64', 'specific:true']
     stage: test
     rules:
         - if: '$BUILD_BENCHMARK != "true"'
@@ -55,7 +55,7 @@ test:lint:
         - yarn run lint
 
 test:js:
-    tags: ['macos:sonoma', 'specific:true']
+    tags: ['macos:sequoia-arm64', 'specific:true']
     stage: test
     rules:
         - if: '$BUILD_BENCHMARK != "true"'
@@ -66,7 +66,7 @@ test:js:
         - NODE_OPTIONS='-r dd-trace/ci/init' DD_ENV=ci DD_SERVICE=dd-sdk-reactnative yarn test
 
 test:build:
-    tags: ['macos:sonoma', 'specific:true']
+    tags: ['macos:sequoia-arm64', 'specific:true']
     stage: test
     rules:
         - if: '$BUILD_BENCHMARK != "true"'
@@ -76,7 +76,7 @@ test:build:
         - yarn prepare
 
 test:native-android:
-    tags: ['macos:sonoma', 'specific:true']
+    tags: ['macos:sequoia-arm64', 'specific:true']
     stage: test
     rules:
         - if: '$BUILD_BENCHMARK != "true"'
@@ -94,7 +94,7 @@ test:native-android:
         - (cd packages/internal-testing-tools/android && ./gradlew build -PDdSdkReactNative_minSdkVersion=24 -PDatadogInternalTesting_minSdkVersion=24)
 
 test:native-ios:
-    tags: ['macos:sonoma', 'specific:true']
+    tags: ['macos:sequoia-arm64', 'specific:true']
     stage: test
     rules:
         - if: '$BUILD_BENCHMARK != "true"'
@@ -102,10 +102,10 @@ test:native-ios:
     script:
         - yarn
         - (cd example/ios && RCT_NEW_ARCH_ENABLED=0 pod install --repo-update)
-        - set -o pipefail && xcodebuild -workspace example/ios/DdSdkReactNativeExample.xcworkspace -scheme DatadogSDKReactNative test -destination "platform=iOS Simulator,OS=17.4,name=iPhone 15 Pro Max" | xcbeautify
+        - set -o pipefail && xcodebuild -workspace example/ios/DdSdkReactNativeExample.xcworkspace -scheme DatadogSDKReactNative test -destination "platform=iOS Simulator,OS=18.5,name=iPhone 16 Pro Max" | xcbeautify
 
 test:native-ios-sr:
-    tags: ['macos:sonoma', 'specific:true']
+    tags: ['macos:sequoia-arm64', 'specific:true']
     stage: test
     rules:
         - if: '$BUILD_BENCHMARK != "true"'
@@ -113,10 +113,10 @@ test:native-ios-sr:
     script:
         - yarn
         - (cd example/ios && RCT_NEW_ARCH_ENABLED=0 pod install --repo-update)
-        - set -o pipefail && xcodebuild -workspace example/ios/DdSdkReactNativeExample.xcworkspace -scheme DatadogSDKReactNativeSessionReplay test -destination "platform=iOS Simulator,OS=17.4,name=iPhone 15 Pro Max" | xcbeautify
+        - set -o pipefail && xcodebuild -workspace example/ios/DdSdkReactNativeExample.xcworkspace -scheme DatadogSDKReactNativeSessionReplay test -destination "platform=iOS Simulator,OS=18.5,name=iPhone 16 Pro Max" | xcbeautify
 
 test:native-ios-newarch:
-    tags: ['macos:sonoma', 'specific:true']
+    tags: ['macos:sequoia-arm64', 'specific:true']
     stage: test
     rules:
         - if: '$BUILD_BENCHMARK != "true"'
@@ -124,7 +124,7 @@ test:native-ios-newarch:
     script:
         - yarn
         - (cd example-new-architecture/ios && RCT_NEW_ARCH_ENABLED=1 pod install --repo-update)
-        - set -o pipefail && xcodebuild -workspace example-new-architecture/ios/DdSdkReactNativeExample.xcworkspace -scheme DatadogSDKReactNative test -destination "platform=iOS Simulator,OS=17.4,name=iPhone 15 Pro Max" | xcbeautify
+        - set -o pipefail && xcodebuild -workspace example-new-architecture/ios/DdSdkReactNativeExample.xcworkspace -scheme DatadogSDKReactNative test -destination "platform=iOS Simulator,OS=18.5,name=iPhone 16 Pro Max" | xcbeautify
 
 benchmark:
     stage: benchmark

--- a/benchmarks/.benchmarks-ci.yml
+++ b/benchmarks/.benchmarks-ci.yml
@@ -60,7 +60,7 @@ stages:
 
 build-and-upload:app:
   stage: build-and-upload
-  tags: ['macos:sonoma', 'specific:true']
+  tags: ['macos:sequoia-arm64', 'specific:true']
   script:
     - !reference [.snippets, install-node]
     - !reference [.snippets, install-android-sdk]


### PR DESCRIPTION
### What does this PR do?

- Migrates CI test jobs from macOS Sonoma runners to macOS Sequoia ARM64 runners. It also updates native iOS tests to use the iOS 18.5 simulator with an iPhone 16 Pro Max.

### Motivation

- Keep the CI environment aligned with the currently supported macOS, Xcode, and iOS simulator infrastructure.
