### PR TITLE
feat: configure flag assignment request limits

### DIFF
--- a/packages/core/android/src/main/kotlin/com/datadog/reactnative/DdFlagsImplementation.kt
+++ b/packages/core/android/src/main/kotlin/com/datadog/reactnative/DdFlagsImplementation.kt
@@ -166,13 +166,19 @@ private fun buildFlagsConfiguration(configuration: Map<String, Any?>): FlagsConf
             (configuration["customExposureEndpoint"] as? String)?.let {
                 useCustomExposureEndpoint("$it/api/v2/exposures")
             }
-            (configuration["assignmentRequestTimeoutMs"] as? Number)?.let {
-                assignmentRequestTimeout(it.toLong())
-            }
-            (configuration["assignmentRequestRetryCount"] as? Number)?.let {
-                assignmentRequestRetryCount(it.toInt())
-            }
+            applyAssignmentRequestConfig(configuration)
         }.build()
+}
+
+private fun FlagsConfiguration.Builder.applyAssignmentRequestConfig(
+    configuration: Map<String, Any?>,
+) {
+    (configuration["assignmentRequestTimeoutMs"] as? Number)?.let {
+        assignmentRequestTimeout(it.toLong())
+    }
+    (configuration["assignmentRequestRetryCount"] as? Number)?.let {
+        assignmentRequestRetryCount(it.toInt())
+    }
 }
 
 private fun buildEvaluationContext(

--- a/packages/core/android/src/main/kotlin/com/datadog/reactnative/DdFlagsImplementation.kt
+++ b/packages/core/android/src/main/kotlin/com/datadog/reactnative/DdFlagsImplementation.kt
@@ -166,6 +166,12 @@ private fun buildFlagsConfiguration(configuration: Map<String, Any?>): FlagsConf
             (configuration["customExposureEndpoint"] as? String)?.let {
                 useCustomExposureEndpoint("$it/api/v2/exposures")
             }
+            (configuration["assignmentRequestTimeoutMs"] as? Number)?.let {
+                assignmentRequestTimeout(it.toLong())
+            }
+            (configuration["assignmentRequestRetryCount"] as? Number)?.let {
+                assignmentRequestRetryCount(it.toInt())
+            }
         }.build()
 }
 

--- a/packages/core/android/src/test/kotlin/com/datadog/reactnative/DdFlagsImplementationTest.kt
+++ b/packages/core/android/src/test/kotlin/com/datadog/reactnative/DdFlagsImplementationTest.kt
@@ -90,7 +90,7 @@ internal class DdFlagsImplementationTest {
             mapOf(
                 "enabled" to true,
                 "assignmentRequestTimeoutMs" to 2_500,
-                "assignmentRequestRetryCount" to 3,
+                "assignmentRequestRetryCount" to 3
             ).toReadableMap()
         val flagsMock = Mockito.mockStatic(Flags::class.java)
 

--- a/packages/core/android/src/test/kotlin/com/datadog/reactnative/DdFlagsImplementationTest.kt
+++ b/packages/core/android/src/test/kotlin/com/datadog/reactnative/DdFlagsImplementationTest.kt
@@ -72,7 +72,7 @@ internal class DdFlagsImplementationTest {
             val configurationCaptor = argumentCaptor<FlagsConfiguration>()
             flagsMock.verify { Flags.enable(configurationCaptor.capture(), same(initializedCore)) }
             assertThat(configurationCaptor.firstValue.readField<Long>("assignmentRequestTimeoutMs"))
-                .isEqualTo(1_000L)
+                .isEqualTo(0L)
             assertThat(configurationCaptor.firstValue.readField<Int>("assignmentRequestRetryCount"))
                 .isEqualTo(1)
             verify(mockPromise).resolve(null)

--- a/packages/core/android/src/test/kotlin/com/datadog/reactnative/DdFlagsImplementationTest.kt
+++ b/packages/core/android/src/test/kotlin/com/datadog/reactnative/DdFlagsImplementationTest.kt
@@ -12,6 +12,7 @@ import com.datadog.android.flags.Flags
 import com.datadog.android.flags.FlagsConfiguration
 import com.datadog.tools.unit.toReadableMap
 import com.facebook.react.bridge.Promise
+import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.extension.ExtendWith
 import org.junit.jupiter.api.extension.Extensions
@@ -19,6 +20,7 @@ import org.mockito.Mock
 import org.mockito.Mockito
 import org.mockito.junit.jupiter.MockitoExtension
 import org.mockito.kotlin.any
+import org.mockito.kotlin.argumentCaptor
 import org.mockito.kotlin.mock
 import org.mockito.kotlin.same
 import org.mockito.kotlin.verify
@@ -67,11 +69,55 @@ internal class DdFlagsImplementationTest {
             testedImplementation.enable(configuration, mockPromise)
 
             // Then
-            flagsMock.verify { Flags.enable(any<FlagsConfiguration>(), same(initializedCore)) }
+            val configurationCaptor = argumentCaptor<FlagsConfiguration>()
+            flagsMock.verify { Flags.enable(configurationCaptor.capture(), same(initializedCore)) }
+            assertThat(configurationCaptor.firstValue.readField<Long>("assignmentRequestTimeoutMs"))
+                .isEqualTo(1_000L)
+            assertThat(configurationCaptor.firstValue.readField<Int>("assignmentRequestRetryCount"))
+                .isEqualTo(1)
             verify(mockPromise).resolve(null)
         } finally {
             flagsMock.close()
             datadogMock.close()
         }
     }
+
+    @Test
+    fun `M forward assignment request configuration W enable() called`() {
+        // Given
+        val sdkCore = mock<SdkCore>()
+        val configuration =
+            mapOf(
+                "enabled" to true,
+                "assignmentRequestTimeoutMs" to 2_500,
+                "assignmentRequestRetryCount" to 3,
+            ).toReadableMap()
+        val flagsMock = Mockito.mockStatic(Flags::class.java)
+
+        try {
+            flagsMock.`when`<Unit> { Flags.enable(any<FlagsConfiguration>(), any()) }.then { }
+            val testedImplementation = DdFlagsImplementation(sdkCore)
+
+            // When
+            testedImplementation.enable(configuration, mockPromise)
+
+            // Then
+            val configurationCaptor = argumentCaptor<FlagsConfiguration>()
+            flagsMock.verify { Flags.enable(configurationCaptor.capture(), same(sdkCore)) }
+            assertThat(configurationCaptor.firstValue.readField<Long>("assignmentRequestTimeoutMs"))
+                .isEqualTo(2_500L)
+            assertThat(configurationCaptor.firstValue.readField<Int>("assignmentRequestRetryCount"))
+                .isEqualTo(3)
+            verify(mockPromise).resolve(null)
+        } finally {
+            flagsMock.close()
+        }
+    }
+
+    @Suppress("UNCHECKED_CAST")
+    private fun <T> Any.readField(name: String): T =
+        javaClass.getDeclaredField(name).run {
+            isAccessible = true
+            get(this@readField) as T
+        }
 }

--- a/packages/core/android/src/test/kotlin/com/datadog/reactnative/DdFlagsImplementationTest.kt
+++ b/packages/core/android/src/test/kotlin/com/datadog/reactnative/DdFlagsImplementationTest.kt
@@ -10,6 +10,7 @@ import com.datadog.android.Datadog
 import com.datadog.android.api.SdkCore
 import com.datadog.android.flags.Flags
 import com.datadog.android.flags.FlagsConfiguration
+import com.datadog.tools.unit.getFieldValue
 import com.datadog.tools.unit.toReadableMap
 import com.facebook.react.bridge.Promise
 import org.assertj.core.api.Assertions.assertThat
@@ -71,10 +72,14 @@ internal class DdFlagsImplementationTest {
             // Then
             val configurationCaptor = argumentCaptor<FlagsConfiguration>()
             flagsMock.verify { Flags.enable(configurationCaptor.capture(), same(initializedCore)) }
-            assertThat(configurationCaptor.firstValue.readField<Long>("assignmentRequestTimeoutMs"))
-                .isEqualTo(0L)
-            assertThat(configurationCaptor.firstValue.readField<Int>("assignmentRequestRetryCount"))
-                .isEqualTo(1)
+            assertThat(
+                configurationCaptor.firstValue
+                    .getFieldValue<Long, FlagsConfiguration>("assignmentRequestTimeoutMs")
+            ).isEqualTo(0L)
+            assertThat(
+                configurationCaptor.firstValue
+                    .getFieldValue<Int, FlagsConfiguration>("assignmentRequestRetryCount")
+            ).isEqualTo(1)
             verify(mockPromise).resolve(null)
         } finally {
             flagsMock.close()
@@ -104,20 +109,18 @@ internal class DdFlagsImplementationTest {
             // Then
             val configurationCaptor = argumentCaptor<FlagsConfiguration>()
             flagsMock.verify { Flags.enable(configurationCaptor.capture(), same(sdkCore)) }
-            assertThat(configurationCaptor.firstValue.readField<Long>("assignmentRequestTimeoutMs"))
-                .isEqualTo(2_500L)
-            assertThat(configurationCaptor.firstValue.readField<Int>("assignmentRequestRetryCount"))
-                .isEqualTo(3)
+            assertThat(
+                configurationCaptor.firstValue
+                    .getFieldValue<Long, FlagsConfiguration>("assignmentRequestTimeoutMs")
+            ).isEqualTo(2_500L)
+            assertThat(
+                configurationCaptor.firstValue
+                    .getFieldValue<Int, FlagsConfiguration>("assignmentRequestRetryCount")
+            ).isEqualTo(3)
             verify(mockPromise).resolve(null)
         } finally {
             flagsMock.close()
         }
     }
 
-    @Suppress("UNCHECKED_CAST")
-    private fun <T> Any.readField(name: String): T =
-        javaClass.getDeclaredField(name).run {
-            isAccessible = true
-            get(this@readField) as T
-        }
 }

--- a/packages/core/ios/Sources/DdFlagsImplementation.swift
+++ b/packages/core/ios/Sources/DdFlagsImplementation.swift
@@ -152,13 +152,22 @@ extension NSDictionary {
             customExposureEndpointURL = URL(string: "\(customExposureEndpoint)/api/v2/exposures" as String)
         }
 
-        return Flags.Configuration(
+        var configuration = Flags.Configuration(
             gracefulModeEnabled: gracefulModeEnabled,
             customFlagsEndpoint: customFlagsEndpointURL,
             customExposureEndpoint: customExposureEndpointURL,
             trackExposures: trackExposures ?? true,
             rumIntegrationEnabled: rumIntegrationEnabled ?? true
         )
+
+        if let assignmentRequestTimeoutMs = object(forKey: "assignmentRequestTimeoutMs") as? NSNumber {
+            configuration.assignmentRequestTimeout = assignmentRequestTimeoutMs.doubleValue / 1_000
+        }
+        if let assignmentRequestRetryCount = object(forKey: "assignmentRequestRetryCount") as? NSNumber {
+            configuration.assignmentRequestRetryCount = assignmentRequestRetryCount.intValue
+        }
+
+        return configuration
     }
 }
 

--- a/packages/core/ios/Tests/DdFlagsTests.swift
+++ b/packages/core/ios/Tests/DdFlagsTests.swift
@@ -316,7 +316,9 @@ class DdFlagsTests: XCTestCase {
             "trackExposures": false,
             "rumIntegrationEnabled": false,
             "customFlagsEndpoint": "https://flags.example.com",
-            "customExposureEndpoint": "https://exposure.example.com"
+            "customExposureEndpoint": "https://exposure.example.com",
+            "assignmentRequestTimeoutMs": 2_500,
+            "assignmentRequestRetryCount": 3
         ]
 
         let config = configDict.asFlagsConfiguration()
@@ -326,6 +328,8 @@ class DdFlagsTests: XCTestCase {
         XCTAssertEqual(config?.rumIntegrationEnabled, false)
         XCTAssertEqual(config?.customFlagsEndpoint?.absoluteString, "https://flags.example.com/precompute-assignments")
         XCTAssertEqual(config?.customExposureEndpoint?.absoluteString, "https://exposure.example.com/api/v2/exposures")
+        XCTAssertEqual(config?.assignmentRequestTimeout, 2.5)
+        XCTAssertEqual(config?.assignmentRequestRetryCount, 3)
     }
 
     func testConfigurationParsingDefaults() {
@@ -337,6 +341,8 @@ class DdFlagsTests: XCTestCase {
         XCTAssertEqual(config?.rumIntegrationEnabled, true)
         XCTAssertNil(config?.customFlagsEndpoint)
         XCTAssertNil(config?.customExposureEndpoint)
+        XCTAssertEqual(config?.assignmentRequestTimeout, 1)
+        XCTAssertEqual(config?.assignmentRequestRetryCount, 1)
     }
 
     func testConfigurationParsingDisabled() {

--- a/packages/core/ios/Tests/DdFlagsTests.swift
+++ b/packages/core/ios/Tests/DdFlagsTests.swift
@@ -341,7 +341,7 @@ class DdFlagsTests: XCTestCase {
         XCTAssertEqual(config?.rumIntegrationEnabled, true)
         XCTAssertNil(config?.customFlagsEndpoint)
         XCTAssertNil(config?.customExposureEndpoint)
-        XCTAssertEqual(config?.assignmentRequestTimeout, 1)
+        XCTAssertEqual(config?.assignmentRequestTimeout, 0)
         XCTAssertEqual(config?.assignmentRequestRetryCount, 1)
     }
 

--- a/packages/core/src/flags/DdFlags.ts
+++ b/packages/core/src/flags/DdFlags.ts
@@ -13,6 +13,37 @@ import { FlagsClient } from './FlagsClient';
 import type { DdFlagsType, FlagsConfiguration } from './types';
 
 const FLAGS_MODULE = 'com.datadog.reactnative.flags';
+const MAX_ASSIGNMENT_REQUEST_RETRY_COUNT = 10;
+
+const validateAssignmentRequestConfiguration = (
+    configuration: FlagsConfiguration
+): void => {
+    const {
+        assignmentRequestTimeoutMs,
+        assignmentRequestRetryCount
+    } = configuration;
+
+    if (
+        assignmentRequestTimeoutMs !== undefined &&
+        (!Number.isSafeInteger(assignmentRequestTimeoutMs) ||
+            assignmentRequestTimeoutMs < 0)
+    ) {
+        throw new Error(
+            '`assignmentRequestTimeoutMs` must be a non-negative integer.'
+        );
+    }
+
+    if (
+        assignmentRequestRetryCount !== undefined &&
+        (!Number.isInteger(assignmentRequestRetryCount) ||
+            assignmentRequestRetryCount < 0 ||
+            assignmentRequestRetryCount > MAX_ASSIGNMENT_REQUEST_RETRY_COUNT)
+    ) {
+        throw new Error(
+            '`assignmentRequestRetryCount` must be an integer between 0 and 10.'
+        );
+    }
+};
 
 /**
  * Implementation class for {@link DdFlagsType}. Please see the interface for documentation.
@@ -32,6 +63,8 @@ class DdFlagsWrapper implements DdFlagsType {
     private clients: Record<string, FlagsClient> = {};
 
     enable = async (configuration: FlagsConfiguration = {}): Promise<void> => {
+        validateAssignmentRequestConfiguration(configuration);
+
         await this.nativeFlags.enable({ enabled: true, ...configuration });
 
         this.isFeatureEnabled = true;

--- a/packages/core/src/flags/__tests__/DdFlags.test.ts
+++ b/packages/core/src/flags/__tests__/DdFlags.test.ts
@@ -58,6 +58,15 @@ describe('DdFlags', () => {
         });
     });
 
+    it('should preserve an omitted assignment request timeout', async () => {
+        await DdFlags.enable({ assignmentRequestRetryCount: 2 });
+
+        expect(NativeModules.DdFlags.enable).toHaveBeenCalledWith({
+            enabled: true,
+            assignmentRequestRetryCount: 2
+        });
+    });
+
     it('should forward zero values that disable assignment request limits', async () => {
         await DdFlags.enable({
             assignmentRequestTimeoutMs: 0,

--- a/packages/core/src/flags/__tests__/DdFlags.test.ts
+++ b/packages/core/src/flags/__tests__/DdFlags.test.ts
@@ -41,6 +41,8 @@ describe('DdFlags', () => {
         await DdFlags.enable({
             customExposureEndpoint: 'https://example.com',
             customFlagsEndpoint: 'https://example.com',
+            assignmentRequestTimeoutMs: 2500,
+            assignmentRequestRetryCount: 3,
             trackExposures: false,
             rumIntegrationEnabled: false
         });
@@ -49,10 +51,51 @@ describe('DdFlags', () => {
             enabled: true,
             customExposureEndpoint: 'https://example.com',
             customFlagsEndpoint: 'https://example.com',
+            assignmentRequestTimeoutMs: 2500,
+            assignmentRequestRetryCount: 3,
             trackExposures: false,
             rumIntegrationEnabled: false
         });
     });
+
+    it('should forward zero values that disable assignment request limits', async () => {
+        await DdFlags.enable({
+            assignmentRequestTimeoutMs: 0,
+            assignmentRequestRetryCount: 0
+        });
+
+        expect(NativeModules.DdFlags.enable).toHaveBeenCalledWith({
+            enabled: true,
+            assignmentRequestTimeoutMs: 0,
+            assignmentRequestRetryCount: 0
+        });
+    });
+
+    it.each([-1, 1.5, Number.NaN, Number.POSITIVE_INFINITY])(
+        'should reject invalid assignmentRequestTimeoutMs value %s',
+        async assignmentRequestTimeoutMs => {
+            await expect(
+                DdFlags.enable({ assignmentRequestTimeoutMs })
+            ).rejects.toThrow(
+                '`assignmentRequestTimeoutMs` must be a non-negative integer.'
+            );
+
+            expect(NativeModules.DdFlags.enable).not.toHaveBeenCalled();
+        }
+    );
+
+    it.each([-1, 11, 1.5, Number.NaN, Number.POSITIVE_INFINITY])(
+        'should reject invalid assignmentRequestRetryCount value %s',
+        async assignmentRequestRetryCount => {
+            await expect(
+                DdFlags.enable({ assignmentRequestRetryCount })
+            ).rejects.toThrow(
+                '`assignmentRequestRetryCount` must be an integer between 0 and 10.'
+            );
+
+            expect(NativeModules.DdFlags.enable).not.toHaveBeenCalled();
+        }
+    );
 
     it('should print an error when trying to retrieve a client before DdFlags.enable() has been called', async () => {
         DdFlags.getClient();

--- a/packages/core/src/flags/types.ts
+++ b/packages/core/src/flags/types.ts
@@ -20,9 +20,11 @@ export interface DdFlagsType {
      * // Initialize the Datadog SDK.
      * await DdSdkReactNative.initialize(...);
      *
-     * // Optinal flags configuration object.
+     * // Optional flags configuration object.
      * const flagsConfig = {
-     *     customFlagsEndpoint: 'https://flags.example.com'
+     *     customFlagsEndpoint: 'https://flags.example.com',
+     *     assignmentRequestTimeoutMs: 1_000,
+     *     assignmentRequestRetryCount: 1
      * };
      *
      * // Enable the feature.
@@ -77,6 +79,30 @@ export interface FlagsConfiguration {
      * @default undefined
      */
     customFlagsEndpoint?: string;
+    /**
+     * Timeout for each request that retrieves precomputed flag assignments, in milliseconds.
+     *
+     * The timeout includes downloading the complete response body. Set to `0` to disable the
+     * timeout. This setting does not apply to loading cached assignments or sending exposure,
+     * evaluation, or RUM data.
+     *
+     * The value must be a non-negative integer.
+     *
+     * @default 1000
+     */
+    assignmentRequestTimeoutMs?: number;
+    /**
+     * Number of times to retry a failed request for precomputed flag assignments.
+     *
+     * This is the number of retries after the initial request. The native SDKs retry transport
+     * errors, timeouts, HTTP `408`, and HTTP `5xx` responses with randomized exponential backoff.
+     * HTTP `429` responses are not retried. Set to `0` to disable retries.
+     *
+     * The value must be an integer between `0` and `10`, inclusive.
+     *
+     * @default 1
+     */
+    assignmentRequestRetryCount?: number;
     /**
      * Custom server URL for sending Flags exposure data.
      *

--- a/packages/core/src/flags/types.ts
+++ b/packages/core/src/flags/types.ts
@@ -82,13 +82,13 @@ export interface FlagsConfiguration {
     /**
      * Timeout for each request that retrieves precomputed flag assignments, in milliseconds.
      *
-     * The timeout includes downloading the complete response body. Set to `0` to disable the
-     * timeout. This setting does not apply to loading cached assignments or sending exposure,
-     * evaluation, or RUM data.
+     * The timeout includes downloading the complete response body. When omitted or set to `0`,
+     * no timeout is applied by Datadog. This setting does not apply to loading cached assignments
+     * or sending exposure, evaluation, or RUM data.
      *
      * The value must be a non-negative integer.
      *
-     * @default 1000
+     * @default undefined
      */
     assignmentRequestTimeoutMs?: number;
     /**

--- a/packages/react-native-openfeature/README.md
+++ b/packages/react-native-openfeature/README.md
@@ -41,7 +41,10 @@ import { OpenFeature } from '@openfeature/react-sdk';
     await DdSdkReactNative.initialize(config);
 
     // Enable Datadog Flags feature after the core SDK has been initialized.
-    await DdFlags.enable();
+    await DdFlags.enable({
+        assignmentRequestTimeoutMs: 1_000,
+        assignmentRequestRetryCount: 1
+    });
 
     // Set the Datadog provider with OpenFeature.
     const provider = new DatadogOpenFeatureProvider();
@@ -53,7 +56,10 @@ import { OpenFeature } from '@openfeature/react-sdk';
 <DatadogProvider
     configuration={coreConfiguration}
     onInitialized={async () => {
-        await DdFlags.enable();
+        await DdFlags.enable({
+            assignmentRequestTimeoutMs: 1_000,
+            assignmentRequestRetryCount: 1
+        });
 
         const provider = new DatadogOpenFeatureProvider();
         OpenFeature.setProvider(provider);
@@ -64,6 +70,11 @@ import { OpenFeature } from '@openfeature/react-sdk';
 ```
 
 After completing this setup, your app is ready for flag evaluation with OpenFeature.
+
+`assignmentRequestTimeoutMs` applies to each flag-assignment request, including downloading the
+response body. `assignmentRequestRetryCount` is the number of retries after the initial request.
+The native SDKs default to a one-second timeout and one retry when these options are omitted. Use
+`0` to disable either limit. These settings do not affect exposure, evaluation, or RUM telemetry.
 
 > **Note**: Sending flag evaluation data to Datadog is automatically enabled when using the Feature Flags SDK. Provide `rumIntegrationEnabled` and `trackExposures` parameters to the `DdFlags.enable()` call to configure.
 

--- a/packages/react-native-openfeature/README.md
+++ b/packages/react-native-openfeature/README.md
@@ -73,8 +73,9 @@ After completing this setup, your app is ready for flag evaluation with OpenFeat
 
 `assignmentRequestTimeoutMs` applies to each flag-assignment request, including downloading the
 response body. `assignmentRequestRetryCount` is the number of retries after the initial request.
-The native SDKs default to a one-second timeout and one retry when these options are omitted. Use
-`0` to disable either limit. These settings do not affect exposure, evaluation, or RUM telemetry.
+The assignment request timeout is disabled when omitted, while the native SDKs default to one
+retry. Use `0` to explicitly disable either limit. These settings do not affect exposure,
+evaluation, or RUM telemetry.
 
 > **Note**: Sending flag evaluation data to Datadog is automatically enabled when using the Feature Flags SDK. Provide `rumIntegrationEnabled` and `trackExposures` parameters to the `DdFlags.enable()` call to configure.
 


### PR DESCRIPTION
## Motivation

React Native applications need the native client assignment-request controls while preserving omission semantics and the no-default-timeout contract.

## Changes

- Add optional `assignmentRequestTimeoutMs` and `assignmentRequestRetryCount` options.
- Validate and serialize explicit values at the JavaScript boundary, including `0` disablement and the `0...10` retry bound.
- Forward values through iOS and Android bridges without synthesizing omitted properties.
- Cover omission, explicit values, zero, invalid input, and both native bridge mappings.
- Reuse the repository reflection helper in Android bridge tests.

## Decisions

- React Native delegates assignment fetching to `dd-sdk-ios` and `dd-sdk-android`; it does not use the browser package or implement a JavaScript transport layer.
- Functions cannot cross the React Native native-module configuration bridge, so the native composable transport building blocks are not exposed as JavaScript callbacks.
- Omitted timeout preserves the native no-SDK-timeout behavior. Retry default remains one retry after the initial request.
- These controls apply only to assignment requests, not cache reads or exposure, evaluation, and RUM telemetry.

## Validation

- Focused Jest suite: 14 tests passed.
- Focused ESLint passes.
- Core Bob CommonJS, module, and TypeScript declaration builds pass.
- `git diff --check` passes.
- Native compilation remains intentionally blocked on the currently pinned iOS and Android releases, which do not yet contain the new APIs.

## Dependencies

- Keep this PR draft until DataDog/dd-sdk-ios#3167 and DataDog/dd-sdk-android#3693 are released, then update `DatadogFlags` and `dd-sdk-android-flags` pins before merge.
