### PR TITLE
feat(flags): send the split serial ID on iOS exposure events (EX-3422)

### DIFF
--- a/packages/core/DatadogSDKReactNative.podspec
+++ b/packages/core/DatadogSDKReactNative.podspec
@@ -19,15 +19,15 @@ Pod::Spec.new do |s|
   s.dependency "React-Core"
 
   # /!\ Remember to keep the versions in sync with DatadogSDKReactNativeSessionReplay.podspec
-  s.dependency 'DatadogCore', '3.16.0'
-  s.dependency 'DatadogLogs', '3.16.0'
-  s.dependency 'DatadogTrace', '3.16.0'
-  s.dependency 'DatadogRUM', '3.16.0'
-  s.dependency 'DatadogCrashReporting', '3.16.0'
-  s.dependency 'DatadogFlags', '3.16.0'
+  s.dependency 'DatadogCore', '3.17.0'
+  s.dependency 'DatadogLogs', '3.17.0'
+  s.dependency 'DatadogTrace', '3.17.0'
+  s.dependency 'DatadogRUM', '3.17.0'
+  s.dependency 'DatadogCrashReporting', '3.17.0'
+  s.dependency 'DatadogFlags', '3.17.0'
 
   # DatadogWebViewTracking is not available for tvOS
-  s.ios.dependency 'DatadogWebViewTracking', '3.16.0'
+  s.ios.dependency 'DatadogWebViewTracking', '3.17.0'
 
   s.test_spec 'Tests' do |test_spec|
     test_spec.source_files = 'ios/Tests/**/*.{swift,json}'

--- a/packages/core/ios/Sources/DdFlagsImplementation.swift
+++ b/packages/core/ios/Sources/DdFlagsImplementation.swift
@@ -172,7 +172,7 @@ extension FlagAssignment {
         case .unknown: NSNull()
         }
 
-        return [
+        var dictionary: [String: Any] = [
             "key": flagKey,
             "value": value,
             "allocationKey": allocationKey,
@@ -184,8 +184,16 @@ extension FlagAssignment {
             "variationValue": "",
             "extraLogging": [:],
         ]
+
+        if let serialID {
+            dictionary[serialIDKey] = String(serialID)
+        }
+
+        return dictionary
     }
 }
+
+private let serialIDKey = "serialId"
 
 extension NSDictionary {
     func asFlagAssignment() -> FlagAssignment? {
@@ -213,7 +221,8 @@ extension NSDictionary {
             variationKey: variationKey,
             variation: variation,
             reason: reason,
-            doLog: doLog
+            doLog: doLog,
+            serialID: (object(forKey: serialIDKey) as? String).flatMap(Int.init)
         )
     }
 }

--- a/packages/core/ios/Tests/DdFlagsTests.swift
+++ b/packages/core/ios/Tests/DdFlagsTests.swift
@@ -368,6 +368,40 @@ class DdFlagsTests: XCTestCase {
         XCTAssertEqual(dict["variationType"] as? String, "")
         XCTAssertEqual(dict["variationValue"] as? String, "")
         XCTAssertNotNil(dict["extraLogging"] as? [String: Any])
+        // An assignment with no serial ID omits the key rather than sending NSNull.
+        XCTAssertNil(dict["serialId"])
+    }
+
+    func testFlagAssignmentToDictionaryCarriesSerialID() {
+        let assignment = FlagAssignment(
+            allocationKey: "alloc",
+            variationKey: "var",
+            variation: .boolean(true),
+            reason: "reason",
+            doLog: true,
+            serialID: 340132
+        )
+
+        let dict = assignment.asDictionary(flagKey: "flag1")
+
+        // Sent as a String because the React Native bridge converts integers to Double.
+        XCTAssertEqual(dict["serialId"] as? String, "340132")
+    }
+
+    func testFlagAssignmentToDictionaryCarriesSerialIDZero() {
+        // Serial IDs are zero-based per org, so 0 is a real value, not an absent one.
+        let assignment = FlagAssignment(
+            allocationKey: "alloc",
+            variationKey: "var",
+            variation: .boolean(true),
+            reason: "reason",
+            doLog: true,
+            serialID: 0
+        )
+
+        let dict = assignment.asDictionary(flagKey: "flag1")
+
+        XCTAssertEqual(dict["serialId"] as? String, "0")
     }
 
     func testDictionaryToFlagAssignment() {
@@ -389,6 +423,71 @@ class DdFlagsTests: XCTestCase {
         } else {
             XCTFail("Expected string variation")
         }
+        XCTAssertNil(assignment?.serialID)
+    }
+
+    func testDictionaryToFlagAssignmentReadsSerialID() {
+        let dict: NSDictionary = [
+            "allocationKey": "alloc",
+            "variationKey": "var",
+            "reason": "reason",
+            "doLog": true,
+            "value": "string_value",
+            "serialId": "340132"
+        ]
+
+        XCTAssertEqual(dict.asFlagAssignment()?.serialID, 340132)
+    }
+
+    func testDictionaryToFlagAssignmentReadsSerialIDZero() {
+        let dict: NSDictionary = [
+            "allocationKey": "alloc",
+            "variationKey": "var",
+            "reason": "reason",
+            "doLog": true,
+            "value": "string_value",
+            "serialId": "0"
+        ]
+
+        XCTAssertEqual(dict.asFlagAssignment()?.serialID, 0)
+    }
+
+    func testDictionaryToFlagAssignmentIgnoresMalformedSerialID() {
+        // A malformed serial ID binds to the serial ID. It must not reject the assignment,
+        // because that would drop the exposure event for the whole flag.
+        let malformedValues: [Any] = ["not-a-number", "", true, 340132]
+
+        for malformed in malformedValues {
+            let dict: NSDictionary = [
+                "allocationKey": "alloc",
+                "variationKey": "var",
+                "reason": "reason",
+                "doLog": true,
+                "value": "string_value",
+                "serialId": malformed
+            ]
+
+            let assignment = dict.asFlagAssignment()
+
+            XCTAssertNotNil(assignment, "Expected an assignment for serialId \(malformed)")
+            XCTAssertNil(assignment?.serialID, "Expected no serial ID for \(malformed)")
+        }
+    }
+
+    func testFlagAssignmentSerialIDSurvivesARoundTrip() {
+        let assignment = FlagAssignment(
+            allocationKey: "alloc",
+            variationKey: "var",
+            variation: .string("string_value"),
+            reason: "reason",
+            doLog: true,
+            serialID: 0
+        )
+
+        let roundTripped = (assignment.asDictionary(flagKey: "flag1") as NSDictionary)
+            .asFlagAssignment()
+
+        XCTAssertEqual(roundTripped?.serialID, 0)
     }
 }
 

--- a/packages/react-native-session-replay/DatadogSDKReactNativeSessionReplay.podspec
+++ b/packages/react-native-session-replay/DatadogSDKReactNativeSessionReplay.podspec
@@ -22,7 +22,7 @@ Pod::Spec.new do |s|
   s.dependency "React-Core"
 
   # /!\ Remember to keep the version in sync with DatadogSDKReactNative.podspec
-  s.dependency 'DatadogSessionReplay', '3.16.0'
+  s.dependency 'DatadogSessionReplay', '3.17.0'
   s.dependency 'DatadogSDKReactNative'
 
   s.test_spec 'Tests' do |test_spec|

--- a/packages/react-native-webview/DatadogSDKReactNativeWebView.podspec
+++ b/packages/react-native-webview/DatadogSDKReactNativeWebView.podspec
@@ -23,8 +23,8 @@ Pod::Spec.new do |s|
   end
 
   # /!\ Remember to keep the version in sync with DatadogSDKReactNative.podspec
-  s.dependency 'DatadogWebViewTracking', '3.16.0'
-  s.dependency 'DatadogInternal', '3.16.0'
+  s.dependency 'DatadogWebViewTracking', '3.17.0'
+  s.dependency 'DatadogInternal', '3.17.0'
   s.dependency 'DatadogSDKReactNative'
 
   s.test_spec 'Tests' do |test_spec|


### PR DESCRIPTION
### What does this PR do?

The iOS bridge now sends the split serial ID on feature flag exposure events.

| File | Change |
|---|---|
| `packages/core/DatadogSDKReactNative.podspec` and 2 other podspecs | Moves the iOS SDK to `3.17.0`. |
| `packages/core/ios/Sources/DdFlagsImplementation.swift` | Reads and writes `serialId` in both bridge directions. |
| `packages/core/ios/Tests/DdFlagsTests.swift` | Adds 6 tests. |

iOS SDK `3.17.0` adds `serialID` to `FlagAssignment`, reads it on the exposure event, and includes it in the exposure deduplication cache. The React Native bridge supplies the value.

The bridge converts a `FlagAssignment` to an `NSDictionary` with a fixed key list, and converts the dictionary back for exposure tracking. The key list omitted the serial ID. The value was therefore dropped in both directions, and the code still compiled.

The serial ID crosses the bridge as a string. Android does the same, because React Native converts integers to `Double`. An assignment with no serial ID omits the key instead of sending `NSNull`.

The reader accepts a string only. `NSNumber` and `Bool` bridge into each other on Apple platforms, so a numeric branch would read a boolean `true` as serial ID `1`. `Int(String)` rejects a boolean, and rejects any other value that is not an integer. A malformed serial ID yields no serial ID. It never rejects the assignment, because that would drop the exposure event for the whole flag.

Serial IDs are zero-based for each org. `0` is therefore a real value, and two tests pin it.

### Motivation

The UFC compiler rewrites a holdout into an ordinary allocation before any SDK reads the flag configuration. An exposure event therefore records no holdout. The split serial ID is the only link back to it. An exposure event without the serial ID cannot be resolved to a holdout.

### Additional Notes

**Testing.** The new tests cover the string form, serial ID `0` in both directions, an absent serial ID omitting the key, four malformed values, and a round trip through both conversions.

**Risks.** The iOS SDK bump from `3.16.0` to `3.17.0` carries every other change in that release.

The bridge ignores a numeric serial ID, whereas the Android bridge accepts a string or a number. Both JavaScript producers send a string, so no current caller depends on the numeric shape. A test pins the numeric case as ignored, so the difference is deliberate and visible.

The offline path also needs the serial ID. PR #1409 covers that, and covers Android.
